### PR TITLE
Fix some small animation issues on tab insertion and removal

### DIFF
--- a/ora/Modules/Sidebar/TabList/NewTabButton.swift
+++ b/ora/Modules/Sidebar/TabList/NewTabButton.swift
@@ -18,8 +18,9 @@ struct NewTabButton: View {
             .foregroundColor(.secondary)
             .padding(8)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isHovering ? theme.activeTabBackground.opacity(0.3) : .clear)
-            .cornerRadius(10)
+            .background(isHovering ? theme.activeTabBackground.opacity(0.3) : .clear, in: .rect(cornerRadius: 10))
+            .contentShape(.rect(cornerRadius: 10))
+            .geometryGroup()
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }

--- a/ora/UI/TabItem.swift
+++ b/ora/UI/TabItem.swift
@@ -127,8 +127,7 @@ struct TabItem: View {
         }
         .padding(8)
         .opacity(isDragging ? 0.0 : 1.0)
-        .background(backgroundColor)
-        .cornerRadius(10)
+        .background(backgroundColor, in: .rect(cornerRadius: 10))
         .overlay(
             isDragging ?
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -138,6 +137,8 @@ struct TabItem: View {
                 )
                 : nil
         )
+        .contentShape(.rect(cornerRadius: 10))
+        .geometryGroup()
         .onTapGesture {
             onTap()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {


### PR DESCRIPTION
- Wrap the contents of tab items and the New Tab button in `.geometryGroup()`. This ensures the entire contents of the tab are animated together, rather than individual subviews moving on their own paths.
- Use .background(_:in:) instead of a separate background modifier and a clip shape. The contents of tabs don't need to be clipped separately since there's padding around them in the tab, and doing this saves an offscreen render pass for each tab (rather than rendering the whole composed tab and then clipping that texture, the renderer can just render a rounded rect in the background).
- Add an explicit `.contentShape` that matches the background rect, which ensures hover always covers the entire bounds of the tab, including the invisible background.

Before: 

https://github.com/user-attachments/assets/96fc983d-39fe-46dc-81d0-5fe91bbed67e

After:

https://github.com/user-attachments/assets/e3a00856-a013-4e56-86bb-07782e541ab8

- **Note**:  This doesn't fully fix the animation issues. The issues go away entirely if I use a SwiftUI `ScrollView`:

https://github.com/user-attachments/assets/bd3f97c8-5ec2-4f65-b4cd-dfef3f8c3da1

So I'm wondering what `VerticalScrollView` is missing to make it work properly. I'm going to tackle this next in a follow-up PR.
