### PR TITLE
fix: app no longer crashes when trying to delete the only container

### DIFF
--- a/ora/Models/History.swift
+++ b/ora/Models/History.swift
@@ -13,7 +13,7 @@ final class History {
     var createdAt: Date
     var visitCount: Int
     var lastAccessedAt: Date
-    @Relationship(inverse: \TabContainer.history) var container: TabContainer
+    @Relationship(inverse: \TabContainer.history) var container: TabContainer?
 
     init(
         id: UUID = UUID(),

--- a/ora/Models/Tab.swift
+++ b/ora/Models/Tab.swift
@@ -51,7 +51,8 @@ class Tab: ObservableObject, Identifiable {
     @Transient @Published var failedURL: URL?
     @Transient @Published var hoveredLinkURL: String?
 
-    @Relationship(inverse: \TabContainer.tabs) var container: TabContainer
+    @Relationship(inverse: \TabContainer.tabs)
+    var container: TabContainer
 
     init(
         id: UUID = UUID(),

--- a/ora/Models/TabContainer.swift
+++ b/ora/Models/TabContainer.swift
@@ -14,7 +14,8 @@ class TabContainer: ObservableObject, Identifiable {
     @Relationship(deleteRule: .cascade)
     var tabs: [Tab] = []
     @Relationship(deleteRule: .cascade) var folders: [Folder] = []
-    @Relationship(deleteRule: .cascade) var history: [History] = []
+    @Relationship
+    var history: [History] = []
 
     init(
         id: UUID = UUID(),

--- a/ora/Services/HistoryManager.swift
+++ b/ora/Services/HistoryManager.swift
@@ -67,7 +67,7 @@ class HistoryManager: ObservableObject {
             predicate = #Predicate { history in
                 (history.urlString.localizedStandardContains(trimmedText) ||
                     history.title.localizedStandardContains(trimmedText)
-                ) && history.container.id == activeContainerId
+                ) && history.container?.id == activeContainerId
             }
         }
 

--- a/ora/Services/TabManager.swift
+++ b/ora/Services/TabManager.swift
@@ -194,7 +194,7 @@ class TabManager: ObservableObject {
         try? modelContext.save()
     }
 
-    func deleteContainer(_ container: TabContainer) -> Bool {
+    func deleteContainer(_ container: TabContainer, deleteHistory: Bool = false) -> Bool {
         do {
             let descriptor = FetchDescriptor<TabContainer>()
             let containers = try modelContext.fetch(descriptor)
@@ -223,8 +223,16 @@ class TabManager: ObservableObject {
                 modelContext.delete(tab)
             }
 
-            for history in container.history {
-                modelContext.delete(history)
+            // delete or keep history
+            if deleteHistory {
+                for h in container.history {
+                    modelContext.delete(h)
+                }
+            } else {
+                // detach history
+                for h in container.history {
+                    h.container = nil
+                }
             }
 
             try modelContext.save()


### PR DESCRIPTION
AI/LLM disclosure:
I have used GPT-5 to better understand the code, and to debug my fix. this is my first time writing swift without a tutorial opened. so if the quality isn't the best, im sorry! (also my first time contributing code to an open source project ._.)

Fatal error: Cannot remove Ora.TabContainer from relationship container on Ora.History because an appropriate default value is not configured. is the error i got in xcode when i:
- opened ora
- clicked on the container emoji icon
- hit delete
i wrote a fix that basically checks the count of all containers and if the count is == 1 it'll return false, and give an alert to the user
