### PR TITLE
Sidebar Fixes (UX)

### DIFF
--- a/ora/Common/Representables/MouseTrackingArea.swift
+++ b/ora/Common/Representables/MouseTrackingArea.swift
@@ -34,7 +34,7 @@ private final class TrackingStrip: NSView {
 
         let area = NSTrackingArea(
             rect: bounds,
-            options: [.mouseEnteredAndExited, .activeInKeyWindow],
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -47,13 +47,17 @@ private final class TrackingStrip: NSView {
     }
 
     override func mouseExited(with event: NSEvent) {
-        let mouse = convert(event.locationInWindow, from: nil)
+        let global = event.locationInWindow
+        let screenPoint = window?.convertPoint(toScreen: global) ?? global
 
-        let xExitCondition = xExit.map { mouse.x > $0 || mouse.x < 0 } ?? true
-        let yExitCondition = yExit.map { mouse.y > $0 || mouse.y < 0 } ?? true
-
-        if xExitCondition || yExitCondition {
-            mouseEntered = false
+        // Check if mouse is still inside the sidebar area
+        if let win = window {
+            let sidebarRect = NSRect(x: 0, y: 0, width: xExit ?? 340, height: win.frame.height)
+            if sidebarRect.contains(win.convertFromScreen(NSRect(origin: screenPoint, size: .zero)).origin) {
+                return // still inside sidebar zone → don’t close
+            }
         }
+
+        mouseEntered = false
     }
 }

--- a/ora/Modules/Sidebar/BottomOption/ContainerSwitcher.swift
+++ b/ora/Modules/Sidebar/BottomOption/ContainerSwitcher.swift
@@ -11,7 +11,9 @@ struct ContainerSwitcher: View {
     @State private var hoveredContainer: UUID?
 
     private let normalButtonWidth: CGFloat = 28
-    private let compactButtonWidth: CGFloat = 12
+    let defaultEmoji = "•"
+    // Never used
+//    private let compactButtonWidth: CGFloat = 12
 
     var body: some View {
         GeometryReader { geometry in
@@ -19,11 +21,11 @@ struct ContainerSwitcher: View {
             let totalWidth =
                 CGFloat(containers.count) * normalButtonWidth + CGFloat(max(0, containers.count - 1))
                     * 2
-            let isCompact = totalWidth > availableWidth
+//            let isCompact = totalWidth > availableWidth
 
-            HStack(alignment: .center, spacing: isCompact ? 4 : 2) {
+            HStack(alignment: .center, spacing: 2 /* isCompact ? 4 : 2 */ ) {
                 ForEach(containers, id: \.id) { container in
-                    containerButton(for: container, isCompact: isCompact)
+                    containerButton(for: container /* , isCompact: isCompact */ )
                 }
             }
             .frame(maxWidth: .infinity, alignment: .center)
@@ -34,15 +36,13 @@ struct ContainerSwitcher: View {
     }
 
     @ViewBuilder
-    private func containerButton(for container: TabContainer, isCompact: Bool) -> some View {
+    private func containerButton(for container: TabContainer /* , isCompact: Bool */ )
+        -> some View
+    { // ditching isCompact -> never used
         let isActive = tabManager.activeContainer?.id == container.id
         let isHovered = hoveredContainer == container.id
-        let displayEmoji =
-            isCompact && !isActive ? (isHovered ? container.emoji : "•") : container.emoji
-        let buttonSize =
-            isCompact && !isActive
-                ? (isHovered ? compactButtonWidth + 4 : compactButtonWidth) : normalButtonWidth
-        let fontSize: CGFloat = isCompact && !isActive ? (isHovered ? 12 : 12) : 12
+        let displayEmoji = container.emoji.isEmpty ? defaultEmoji : container.emoji
+        let fontSize = dynamicFontSize(for: displayEmoji, isActive: isActive)
 
         Button(action: {
             onContainerSelected(container)
@@ -50,34 +50,46 @@ struct ContainerSwitcher: View {
             HStack {
                 Text(displayEmoji)
                     .font(.system(size: fontSize))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(displayEmoji == defaultEmoji ? .primary : .secondary)
             }
-            .frame(width: buttonSize, height: buttonSize)
+            .frame(width: normalButtonWidth, height: normalButtonWidth)
             .grayscale(!isActive && !isHovered ? 0.5 : 0)
-            .opacity(!isCompact && !isActive && !isHovered ? 0.5 : 1)
+            .opacity(!isActive ? 0.5 : 1)
             .background(
-                !isCompact && isHovered
-                    ? theme.invertedSolidWindowBackgroundColor.opacity(0.3)
-                    : isActive
-                    ? theme.invertedSolidWindowBackgroundColor.opacity(0.2)
-                    : .clear
+                buttonBackground(isActive: isActive, isHovered: isHovered, emoji: displayEmoji)
             )
             .cornerRadius(8)
         }
         .buttonStyle(.plain)
         .animation(.easeOut(duration: 0.15), value: isActive || isHovered)
-        .onHover { isHovering in
-            withAnimation(.easeOut(duration: 0.15)) {
-                hoveredContainer = isHovering ? container.id : nil
-            }
+        .onHover { hoveredContainer = $0 ? container.id : nil }
+        .contextMenu { contextMenuButtons(for: container) }
+    }
+
+    private func dynamicFontSize(for emoji: String, isActive: Bool) -> CGFloat {
+        // normal emojis are sized correctly
+        emoji == defaultEmoji ? 24 : 12
+        // resize `dot` accordingly
+    }
+
+    private func buttonBackground(isActive: Bool, isHovered: Bool, emoji: String) -> Color {
+        if isHovered {
+            return theme.invertedSolidWindowBackgroundColor.opacity(0.3)
+        } else if isActive, emoji != defaultEmoji {
+            return theme.invertedSolidWindowBackgroundColor.opacity(0.2)
         }
-        .contextMenu {
-            Button("Rename Container") {
-                // tabManager.renameContainer(container, name: "New Name", emoji: "💩")
-            }
-            Button("Delete Container") {
-                tabManager.deleteContainer(container)
-            }
+        return .clear
+    }
+
+    @ViewBuilder
+    private func contextMenuButtons(for container: TabContainer) -> some View {
+        Button("Rename Container") {
+            // tabManager.renameContainer(container, name: "New Name", emoji: "💩")
         }
+
+        Button("Delete Container") {
+            tabManager.deleteContainer(container)
+        }
+        .disabled(containers.count == 1) // disabled to avoid crashes
     }
 }

--- a/ora/Modules/Sidebar/BottomOption/NewContainerButton.swift
+++ b/ora/Modules/Sidebar/BottomOption/NewContainerButton.swift
@@ -37,12 +37,24 @@ struct NewContainerButton: View {
                     Button(action: {
                         isEmojiPickerOpen.toggle()
                     }) {
-                        if emoji.isEmpty {
-                            Image(systemName: "plus")
-                                .font(.system(size: 12))
-                        } else {
-                            Text(emoji)
-                                .font(.system(size: 12))
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .stroke(
+                                    emoji.isEmpty ? theme.border : theme.border,
+                                    style: emoji.isEmpty
+                                        ? StrokeStyle(lineWidth: 1, dash: [5])
+                                        : StrokeStyle(lineWidth: 1)
+                                )
+                                .animation(.easeOut(duration: 0.1), value: emoji.isEmpty)
+                                .background(isEmojiPickerHovering ? Color.gray.opacity(0.3) : Color.gray.opacity(0.2))
+                                .cornerRadius(10)
+                            if emoji.isEmpty {
+                                Image(systemName: "plus")
+                                    .font(.system(size: 12))
+                            } else {
+                                Text(emoji)
+                                    .font(.system(size: 12))
+                            }
                         }
                     }
                     .popover(isPresented: $isEmojiPickerOpen, arrowEdge: .bottom) {
@@ -52,16 +64,6 @@ struct NewContainerButton: View {
                         })
                     }
                     .frame(width: 32, height: 32)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(
-                                emoji.isEmpty ? theme.border : theme.border,
-                                style: emoji.isEmpty
-                                    ? StrokeStyle(lineWidth: 1, dash: [5])
-                                    : StrokeStyle(lineWidth: 1)
-                            )
-                            .animation(.easeOut(duration: 0.1), value: emoji.isEmpty)
-                    )
                     .background(isEmojiPickerHovering ? Color.gray.opacity(0.3) : Color.gray.opacity(0.2))
                     .cornerRadius(10)
                     .buttonStyle(.plain)
@@ -92,10 +94,11 @@ struct NewContainerButton: View {
                 }
 
                 Button("Create") {
-                    tabManager.createContainer(name: name, emoji: emoji)
+                    let defaultEmoji = "•"
+                    tabManager.createContainer(name: name, emoji: emoji.isEmpty ? defaultEmoji : emoji)
                     isPopoverOpen = false
                 }
-                .disabled(name.isEmpty || emoji.isEmpty)
+                .disabled(name.isEmpty)
             }
             .frame(width: 300)
             .padding()

--- a/ora/Modules/Sidebar/FloatingSidebar.swift
+++ b/ora/Modules/Sidebar/FloatingSidebar.swift
@@ -3,15 +3,16 @@ import SwiftUI
 struct FloatingSidebar: View {
     let isFullscreen: Bool
     @Environment(\.theme) var theme
+    let sidebarCornerRadius: CGFloat = 12
 
     var body: some View {
         ZStack(alignment: .leading) {
             SidebarView(isFullscreen: isFullscreen)
                 .background(theme.subtleWindowBackgroundColor)
                 .background(BlurEffectView(material: .popover, blendingMode: .withinWindow))
-                .cornerRadius(12)
+                .cornerRadius(sidebarCornerRadius)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    RoundedRectangle(cornerRadius: sidebarCornerRadius, style: .continuous)
                         .stroke(theme.invertedSolidWindowBackgroundColor.opacity(0.3), lineWidth: 1)
                 )
         }


### PR DESCRIPTION
- Made MouseTrackingArea Global instead of view local. -> Fixes popOver cancellation
- Fixed Create New Container Button -> Allows for you to create a new container with a default icon but requires a name.
- Changed hit-box from emoji to the button instead.
- UI Fixes for said container button -> opted for a View Scoped variable for a defaultEmoji.
- Removes isCompact bool -> Never used, Default condition applies instead.
- Logic separated into functions.

#28 Reopened after rebase changes