### PR TITLE
fix: limit bubble link to 1 line and truncate at the middle

### DIFF
--- a/ora/Modules/Browser/BrowserView.swift
+++ b/ora/Modules/Browser/BrowserView.swift
@@ -222,6 +222,9 @@ struct BrowserView: View {
                                         Text(hovered)
                                             .font(.system(size: 12, weight: .regular))
                                             .foregroundStyle(theme.foreground)
+                                            .lineLimit(1)
+                                            .truncationMode(.middle)
+                                            .multilineTextAlignment(.leading)
                                             .padding(.horizontal, 10)
                                             .padding(.vertical, 6)
                                             .background(


### PR DESCRIPTION
**Before**
<img width="1655" height="990" alt="Снимок экрана 2025-09-09 в 18 45 37" src="https://github.com/user-attachments/assets/f799852c-ef14-490f-94e1-2c13327c8bb2" />


**After**

<img width="1704" height="92" alt="Снимок экрана 2025-09-09 в 18 59 10" src="https://github.com/user-attachments/assets/3cc176a2-c52b-45dd-b39d-aa6264ffff67" />
