### PR TITLE
feat: add copy link button in url

### DIFF
--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -173,24 +173,28 @@ struct URLBar: View {
                                 }
                             }
                         )
-                        // Hidden button for copy shortcut
-                        .overlay(
-                            Button("") {
-                                copyToClipboard(tab.url.absoluteString)
+                        Button {
+                            copyToClipboard(tab.url.absoluteString)
+                            withAnimation {
+                                showCopiedAnimation = true
+                                startWheelAnimation = true
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                                 withAnimation {
-                                    showCopiedAnimation = true
-                                    startWheelAnimation = true
-                                }
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                                    withAnimation {
-                                        showCopiedAnimation = false
-                                        startWheelAnimation = false
-                                    }
+                                    showCopiedAnimation = false
+                                    startWheelAnimation = false
                                 }
                             }
-                            .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
-                            .opacity(0)
-                        )
+                        } label: {
+                            Image(systemName: "link")
+                                .font(.system(size: 12, weight: .regular))
+                                .foregroundColor(getUrlFieldColor(tab))
+                                .frame(width: 16, height: 16)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Copy URL (⇧⌘C)")
+                        .accessibilityLabel(Text("Copy URL"))
+                        .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)


### PR DESCRIPTION
As a user I don't like a shortcut to copy a link, I really prefer a button

**Before**

<img width="1189" height="46" alt="Снимок экрана 2025-09-09 в 19 19 25" src="https://github.com/user-attachments/assets/5bfd6f3f-b0ec-4d3a-84a2-8493cd752dd2" />


**After**

<img width="1182" height="50" alt="Снимок экрана 2025-09-09 в 19 18 35" src="https://github.com/user-attachments/assets/387252e9-9cc4-4068-865c-7747ae454553" />
