### PR TITLE
feat: draggable sidebar on macOS 15+

### DIFF
--- a/ora/Modules/Sidebar/ContainerView.swift
+++ b/ora/Modules/Sidebar/ContainerView.swift
@@ -50,6 +50,7 @@ struct ContainerView: View {
                 }
             }
         }
+        .modifier(WindowDragIfAvailable())
     }
 
     private var favoriteTabs: [Tab] {
@@ -112,6 +113,16 @@ struct ContainerView: View {
 
     private func dropTab(_ tabId: String) {
         draggedItem = nil
+    }
+}
+
+private struct WindowDragIfAvailable: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 15.0, *) {
+            content.gesture(WindowDragGesture())
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #65 
Dragging the sidebar will move the window for macOS 15+ since the API is not available on macOS 14. Uses a custom view modifier to conditionally apply the gesture.

> I chatted with Claude on how to best apply the gesture conditionally to support macOS 14. The `WindowDragIfAvailable` struct was generated by Claude. I reviewed all the code myself and it looks good.