### PR TITLE
feat: Add double-click to rename tabs functionality

### DIFF
--- a/ora/Models/Tab.swift
+++ b/ora/Models/Tab.swift
@@ -24,6 +24,7 @@ class Tab: ObservableObject, Identifiable {
     var urlString: String
     var savedURL: URL?
     var title: String
+    var customTitle: String? // User-defined custom title
     var favicon: URL? // Add favicon property
     var createdAt: Date
     var lastAccessedAt: Date?
@@ -57,6 +58,7 @@ class Tab: ObservableObject, Identifiable {
         id: UUID = UUID(),
         url: URL,
         title: String,
+        customTitle: String? = nil,
         favicon: URL? = nil,
         container: TabContainer,
         type: TabType = .normal,
@@ -72,6 +74,7 @@ class Tab: ObservableObject, Identifiable {
         self.urlString = url.absoluteString
 
         self.title = title
+        self.customTitle = customTitle
         self.favicon = favicon
         self.createdAt = nowDate
         self.lastAccessedAt = nowDate
@@ -117,6 +120,11 @@ class Tab: ObservableObject, Identifiable {
         }
     }
 
+    // Computed property to get the title to display (custom title takes precedence)
+    var displayTitle: String {
+        return customTitle ?? title
+    }
+    
     func syncBackgroundColorFromHex() {
         backgroundColor = Color(hex: backgroundColorHex)
     }

--- a/ora/Modules/Launcher/Main/LauncherMain.swift
+++ b/ora/Modules/Launcher/Main/LauncherMain.swift
@@ -138,7 +138,7 @@ struct LauncherMain: View {
             suggestions.append(
                 LauncherSuggestion(
                     type: .openedTab,
-                    title: tab.title,
+                    title: tab.displayTitle,
                     url: tab.url,
                     faviconURL: tab.favicon,
                     faviconLocalFile: tab.faviconLocalFile,

--- a/ora/Modules/TabSwitch/FloatingTabSwitcher.swift
+++ b/ora/Modules/TabSwitch/FloatingTabSwitcher.swift
@@ -176,7 +176,7 @@ struct FloatingTabSwitcher: View {
             )
             .frame(width: 16, height: 16)
 
-            Text(tab.title)
+            Text(tab.displayTitle)
                 .font(.system(size: 12))
                 .foregroundColor(theme.foreground)
                 .lineLimit(1)

--- a/ora/Services/TabManager.swift
+++ b/ora/Services/TabManager.swift
@@ -363,7 +363,7 @@ class TabManager: ObservableObject {
         if message.name == "listener",
            let url = message.body as? String
         {
-            // You can update the active tab’s url if needed
+            // You can update the active tab's url if needed
             DispatchQueue.main.async {
                 if let validURL = URL(string: url) {
                     self.activeTab?.url = validURL
@@ -374,5 +374,11 @@ class TabManager: ObservableObject {
                 }
             }
         }
+    }
+    
+    // MARK: - Persistence
+    
+    func saveChanges() {
+        try? modelContext.save()
     }
 }

--- a/ora/UI/EditableTabTitle.swift
+++ b/ora/UI/EditableTabTitle.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+struct EditableTabTitle: View {
+    let tab: Tab
+    let isSelected: Bool
+    let textColor: Color
+    @Binding var isEditing: Bool
+    @State private var editingText = ""
+    @FocusState private var isFocused: Bool
+    @EnvironmentObject var tabManager: TabManager
+    
+    var body: some View {
+        Group {
+            if isEditing {
+                TextField("Tab name", text: $editingText, onCommit: {
+                    saveTitle()
+                })
+                .textFieldStyle(.plain)
+                .font(.system(size: 13))
+                .foregroundColor(textColor)
+                .focused($isFocused)
+                .background(Color.white.opacity(0.1))
+                .cornerRadius(4)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .onAppear {
+                    editingText = tab.displayTitle
+                    // Delay focus to ensure the text field is ready
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        isFocused = true
+                    }
+                }
+                .onSubmit {
+                    saveTitle()
+                }
+                .onExitCommand {
+                    cancelEditing()
+                }
+            } else {
+                Text(tab.displayTitle)
+                    .font(.system(size: 13))
+                    .foregroundColor(textColor)
+                    .lineLimit(1)
+                    .onTapGesture(count: 2) {
+                        startEditing()
+                    }
+            }
+        }
+        .onChange(of: isEditing) { _, newValue in
+            if newValue {
+                editingText = tab.displayTitle
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    isFocused = true
+                }
+            }
+        }
+    }
+    
+    private func startEditing() {
+        editingText = tab.displayTitle
+        isEditing = true
+        // Ensure focus is set
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            isFocused = true
+        }
+    }
+    
+    private func saveTitle() {
+        let trimmedText = editingText.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // If the edited text is empty or the same as the original title, 
+        // clear the custom title
+        if trimmedText.isEmpty || trimmedText == tab.title {
+            tab.customTitle = nil
+        } else {
+            tab.customTitle = trimmedText
+        }
+        
+        // Save to persistence
+        tabManager.saveChanges()
+        
+        isEditing = false
+        isFocused = false
+    }
+    
+    private func cancelEditing() {
+        isEditing = false
+        isFocused = false
+        editingText = tab.displayTitle
+    }
+}

--- a/ora/UI/TabItem.swift
+++ b/ora/UI/TabItem.swift
@@ -89,6 +89,7 @@ struct TabItem: View {
 
     @Environment(\.theme) private var theme
     @State private var isHovering = false
+    @State private var isEditingTitle = false
 
     var body: some View {
         HStack {
@@ -158,10 +159,12 @@ struct TabItem: View {
     }
 
     private var tabTitle: some View {
-        Text(tab.title)
-            .font(.system(size: 13))
-            .foregroundColor(textColor)
-            .lineLimit(1)
+        EditableTabTitle(
+            tab: tab,
+            isSelected: isSelected,
+            textColor: textColor,
+            isEditing: $isEditingTitle
+        )
     }
 
     private var backgroundColor: Color {
@@ -190,6 +193,12 @@ struct TabItem: View {
 
     @ViewBuilder
     private var contextMenuItems: some View {
+        Button(action: { isEditingTitle = true }) {
+            Label("Rename Tab", systemImage: "pencil")
+        }
+        
+        Divider()
+        
         Button(action: onPinToggle) {
             Label(
                 tab.type == .pinned ? "Unpin Tab" : "Pin Tab",


### PR DESCRIPTION
## Description
This PR adds the ability to rename tabs with custom titles, making it easier to organize and identify tabs when working with many open pages.

## Features
- Double-click on any tab title to rename it inline
- Right-click context menu option "Rename Tab" with pencil icon
- Custom titles persist across sessions
- Press Enter to save or Escape to cancel editing
- Custom titles take precedence over page titles in display

## Implementation
- Added `customTitle` property to Tab model for user-defined names
- Created `EditableTabTitle` component with inline editing capability
- Added `displayTitle` computed property that prioritizes custom title over page title
- Updated all tab title references to use `displayTitle`
- Added `saveChanges()` method to TabManager for persistence

## Note
This PR is a cleaned-up version of #74, containing only the rename functionality. The folder management features are in a separate PR (#72) as requested in the review feedback.

## AI Disclosure
This code was developed with assistance from Claude 4.1 Opus