### PR TITLE
feat(toolbar): add slide transition to toolbar on toggle

### DIFF
--- a/ora/Modules/Browser/BrowserView.swift
+++ b/ora/Modules/Browser/BrowserView.swift
@@ -184,6 +184,10 @@ struct BrowserView: View {
                 URLBar(
                     onSidebarToggle: { toggleSidebar() }
                 )
+                .transition(.asymmetric(
+                    insertion: .push(from: .top),
+                    removal: .push(from: .bottom)
+                ))
             }
             if let tab = tabManager.activeTab {
                 if tab.isWebViewReady {

--- a/ora/Modules/Sidebar/SidebarView.swift
+++ b/ora/Modules/Sidebar/SidebarView.swift
@@ -37,6 +37,10 @@ struct SidebarView: View {
                     tab: tab,
                     editingURLString: $editingURLString
                 )
+                .transition(.asymmetric(
+                    insertion: .push(from: .top).combined(with: .opacity),
+                    removal: .push(from: .bottom).combined(with: .opacity)
+                ))
             }
 
             NSPageView(

--- a/ora/oraApp.swift
+++ b/ora/oraApp.swift
@@ -1,7 +1,7 @@
+import AppKit
 import Foundation
 import SwiftData
 import SwiftUI
-import AppKit
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -282,12 +282,16 @@ struct OraApp: App {
             CommandGroup(replacing: .toolbar) {
                 if appState.isToolbarHidden {
                     Button("Show Toolbar") {
-                        appState.isToolbarHidden = false
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            appState.isToolbarHidden = false
+                        }
                     }
                     .keyboardShortcut("d", modifiers: [.command, .shift])
                 } else {
                     Button("Hide Toolbar") {
-                        appState.isToolbarHidden = true
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            appState.isToolbarHidden = true
+                        }
                     }
                     .keyboardShortcut("d", modifiers: [.command, .shift])
                 }


### PR DESCRIPTION
# Description

I just added a tiny transition when the toolbar is toggled. Now it feels smoother.

https://github.com/user-attachments/assets/4f97066b-cc38-4d37-829a-06dac54ac8b3

