### PR TITLE
fix: searching for text in url bar

### DIFF
--- a/ora/Models/History.swift
+++ b/ora/Models/History.swift
@@ -14,7 +14,7 @@ final class History {
     var visitCount: Int
     var lastAccessedAt: Date
 
-    @Relationship(inverse: \TabContainer.history) var container: TabContainer? = nil
+    @Relationship(inverse: \TabContainer.history) var container: TabContainer?
 
     init(
         id: UUID = UUID(),

--- a/ora/Models/Tab.swift
+++ b/ora/Models/Tab.swift
@@ -191,8 +191,7 @@ class Tab: ObservableObject, Identifiable {
         }
     }
 
-    public func setupNavigationDelegate() {
-
+    func setupNavigationDelegate() {
         let delegate = WebViewNavigationDelegate()
         delegate.tab = self
         delegate.onStart = { [weak self] in
@@ -306,16 +305,28 @@ class Tab: ObservableObject, Identifiable {
     }
 
     func loadURL(_ urlString: String) {
-        var finalURLString = urlString
+        let input = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Add https:// if no protocol specified
-        if !urlString.contains("://") {
-            finalURLString = "https://" + urlString
+        // 1) Try to construct a direct URL (has scheme or valid domain+TLD/IP)
+        if let directURL = constructURL(from: input) {
+            webView.load(URLRequest(url: directURL))
+            return
         }
 
-        if let url = URL(string: finalURLString) {
-            let request = URLRequest(url: url)
-            webView.load(request)
+        // 2) Otherwise, treat as a search query using the selected search engine
+        let searchEngineService = SearchEngineService()
+        if let engine = searchEngineService.getDefaultSearchEngine(for: self.container.id),
+           let searchURL = searchEngineService.createSearchURL(for: engine, query: input)
+        {
+            webView.load(URLRequest(url: searchURL))
+            return
+        }
+
+        // 3) Fallback to Google if for some reason engine lookup fails
+        if let fallbackURL = URL(string: "https://www.google.com/search?client=safari&rls=en&ie=UTF-8&oe=UTF-8&q="
+            + (input.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")
+        ) {
+            webView.load(URLRequest(url: fallbackURL))
         }
     }
 

--- a/ora/Services/PrivacyService.swift
+++ b/ora/Services/PrivacyService.swift
@@ -9,7 +9,6 @@ enum CookiesPolicy: String, CaseIterable, Identifiable, Codable {
 }
 
 class PrivacyService {
-
     private static func clearData(_ container: TabContainer, _ types: Set<String>, _ completion: (() -> Void)?) {
         let dataStore =  WKWebsiteDataStore(forIdentifier: container.id)
         dataStore

--- a/ora/Services/TabManager.swift
+++ b/ora/Services/TabManager.swift
@@ -327,7 +327,6 @@ class TabManager: ObservableObject {
         try? modelContext.save() // Persist the undo operation
     }
 
-
     func activateContainer(_ container: TabContainer, activateLastAccessedTab: Bool = true) {
         activeContainer = container
         container.lastAccessedAt = Date()

--- a/ora/Services/TabScriptHandler.swift
+++ b/ora/Services/TabScriptHandler.swift
@@ -65,7 +65,6 @@ class TabScriptHandler: NSObject, WKScriptMessageHandler {
         }
     }
 
-
     func customWKConfig(containerId: UUID, temporaryStorage: Bool = false) -> WKWebViewConfiguration {
         // Configure WebView for performance
         let configuration = WKWebViewConfiguration()

--- a/ora/Services/UpdateService.swift
+++ b/ora/Services/UpdateService.swift
@@ -21,7 +21,6 @@ class UpdateService: NSObject, ObservableObject {
     }
 
     private func setupUpdater() {
-
         let hostBundle = Bundle.main
         let applicationBundle = hostBundle
         let userDriver = SPUStandardUserDriver(hostBundle: hostBundle, delegate: nil)


### PR DESCRIPTION
**Before**

When searching for a text it's add `https://` at the start of the string

**After**

https://www.loom.com/share/4238082ff5e7498e8fad2a2022031fb9