### PR TITLE
Fix copy URL bug - closure capture issue

### DIFF
--- a/ora/Common/Utils/ClipboardUtils.swift
+++ b/ora/Common/Utils/ClipboardUtils.swift
@@ -1,0 +1,37 @@
+import AppKit
+import SwiftUI
+
+/// Utility functions for clipboard operations
+struct ClipboardUtils {
+    /// Copies the given text to the system clipboard
+    static func copyToClipboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    /// Triggers copy with animation states
+    /// - Parameters:
+    ///   - text: The text to copy
+    ///   - showCopiedAnimation: Binding to control animation visibility
+    ///   - startWheelAnimation: Binding to control wheel animation
+    static func triggerCopy(
+        _ text: String,
+        showCopiedAnimation: Binding<Bool>,
+        startWheelAnimation: Binding<Bool>
+    ) {
+        // Prevent double-trigger if both Command and view shortcut fire
+        if showCopiedAnimation.wrappedValue { return }
+        copyToClipboard(text)
+        withAnimation {
+            showCopiedAnimation.wrappedValue = true
+            startWheelAnimation.wrappedValue = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            withAnimation {
+                showCopiedAnimation.wrappedValue = false
+                startWheelAnimation.wrappedValue = false
+            }
+        }
+    }
+}

--- a/ora/Modules/Sidebar/SidebarURLDisplay.swift
+++ b/ora/Modules/Sidebar/SidebarURLDisplay.swift
@@ -18,25 +18,8 @@ struct SidebarURLDisplay: View {
         self._editingURLString = editingURLString
     }
 
-    private func copyToClipboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-    }
-
     private func triggerCopy(_ text: String) {
-        if showCopiedAnimation { return }
-        copyToClipboard(text)
-        withAnimation {
-            showCopiedAnimation = true
-            startWheelAnimation = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            withAnimation {
-                showCopiedAnimation = false
-                startWheelAnimation = false
-            }
-        }
+        ClipboardUtils.triggerCopy(text, showCopiedAnimation: $showCopiedAnimation, startWheelAnimation: $startWheelAnimation)
     }
 
     var body: some View {

--- a/ora/Modules/Sidebar/SidebarURLDisplay.swift
+++ b/ora/Modules/Sidebar/SidebarURLDisplay.swift
@@ -104,7 +104,6 @@ struct SidebarURLDisplay: View {
                 Button("") {
                     triggerCopy(tab.url.absoluteString)
                 }
-                .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
                 .opacity(0)
             )
         }

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -210,7 +210,6 @@ struct URLBar: View {
                         .buttonStyle(.plain)
                         .help("Copy URL (⇧⌘C)")
                         .accessibilityLabel(Text("Copy URL"))
-                        .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -171,7 +171,9 @@ struct URLBar: View {
                         .font(.system(size: 14))
                         .foregroundColor(getUrlFieldColor(tab))
                         .onTapGesture {
-                            editingURLString = tab.url.absoluteString
+                            if let activeTab = tabManager.activeTab {
+                                editingURLString = activeTab.url.absoluteString
+                            }
                             isEditing = true
                         }
                         .onKeyPress(.escape) {
@@ -196,7 +198,9 @@ struct URLBar: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                         Button {
-                            triggerCopy(tab.url.absoluteString)
+                            if let activeTab = tabManager.activeTab {
+                                triggerCopy(activeTab.url.absoluteString)
+                            }
                         } label: {
                             Image(systemName: "link")
                                 .font(.system(size: 12, weight: .regular))

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -32,26 +32,8 @@ struct URLBar: View {
         return tabManager.activeTab.map { getForegroundColor($0).opacity(isEditing ? 1.0 : 0.5) } ?? .gray
     }
 
-    private func copyToClipboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-    }
-
     private func triggerCopy(_ text: String) {
-        // Prevent double-trigger if both Command and view shortcut fire
-        if showCopiedAnimation { return }
-        copyToClipboard(text)
-        withAnimation {
-            showCopiedAnimation = true
-            startWheelAnimation = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            withAnimation {
-                showCopiedAnimation = false
-                startWheelAnimation = false
-            }
-        }
+        ClipboardUtils.triggerCopy(text, showCopiedAnimation: $showCopiedAnimation, startWheelAnimation: $startWheelAnimation)
     }
 
     var buttonForegroundColor: Color {


### PR DESCRIPTION
The URL copy functionality was only copying the first opened tab's URL due to a closure capture issue in URLBar.swift. The button click and tap gesture closures were capturing the 'tab' variable by value instead of using the current active tab.

Fixed by updating both the copy button action and URL field tap gesture to use tabManager.activeTab directly instead of the captured tab variable.

Resolves #84 