### PR TITLE
Feature: allow middle click to open link in new tab

### DIFF
--- a/ora/Services/TabManager.swift
+++ b/ora/Services/TabManager.swift
@@ -233,6 +233,7 @@ class TabManager: ObservableObject {
         url: URL,
         historyManager: HistoryManager,
         downloadManager: DownloadManager? = nil,
+        focusAfterOpening: Bool = true,
         isPrivate: Bool
     ) {
         if let container = activeContainer {
@@ -256,10 +257,14 @@ class TabManager: ObservableObject {
                 )
                 modelContext.insert(newTab)
                 container.tabs.append(newTab)
-                activeTab?.maybeIsActive  = false
-                activeTab = newTab
-                activeTab?.maybeIsActive = true
-                newTab.lastAccessedAt = Date()
+
+                if focusAfterOpening {
+                    activeTab?.maybeIsActive  = false
+                    activeTab = newTab
+                    activeTab?.maybeIsActive = true
+                    newTab.lastAccessedAt = Date()
+                }
+
                 container.lastAccessedAt = Date()
                 try? modelContext.save()
             }

--- a/ora/UI/WebView.swift
+++ b/ora/UI/WebView.swift
@@ -75,7 +75,7 @@ struct WebView: NSViewRepresentable {
         func setupMouseEventMonitoring(for webView: WKWebView) {
             self.webView = webView
 
-            // Monitor for other mouse button events (buttons 4 and 5)
+            // Monitor for other mouse button events (buttons 3, 4 and 5)
             mouseEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.otherMouseDown]) { [weak self] event in
                 guard let self,
                       let webView = self.webView,
@@ -84,9 +84,9 @@ struct WebView: NSViewRepresentable {
                     return event
                 }
 
-                // Handle mouse button events for back/forward navigation
+                // Handle mouse button events for back/forward navigation and middle-click to open link in new tab
                 switch event.buttonNumber {
-                case 2: // Middle mouse button
+                case 2: // Mouse button 3 (middle click to open link in new tab)
                     handleMiddleClick(at: event.locationInWindow, webView: webView)
                     return nil
                 case 3: // Mouse button 4 (back)
@@ -111,6 +111,13 @@ struct WebView: NSViewRepresentable {
 
         private func handleMiddleClick(at location: NSPoint, webView: WKWebView) {
             let locationInWebView = webView.convert(location, from: nil)
+
+            // Ensure the coordinates are within the web view bounds
+            guard locationInWebView.x.isFinite, locationInWebView.y.isFinite,
+                  locationInWebView.x >= 0, locationInWebView.y >= 0
+            else {
+                return
+            }
 
             let jsCode = """
                 (function() {

--- a/ora/UI/WebView.swift
+++ b/ora/UI/WebView.swift
@@ -133,12 +133,14 @@ struct WebView: NSViewRepresentable {
                 if let urlString = result as? String, let url = URL(string: urlString),
                    let tabManager = self?.tabManager, let historyManager = self?.historyManager
                 {
-                    tabManager.openTab(
-                        url: url,
-                        historyManager: historyManager,
-                        focusAfterOpening: false,
-                        isPrivate: self?.privacyMode?.isPrivate ?? false
-                    )
+                    DispatchQueue.main.async {
+                        tabManager.openTab(
+                            url: url,
+                            historyManager: historyManager,
+                            focusAfterOpening: false,
+                            isPrivate: self?.privacyMode?.isPrivate ?? false
+                        )
+                    }
                 }
             }
         }

--- a/ora/UI/WebView.swift
+++ b/ora/UI/WebView.swift
@@ -129,9 +129,15 @@ struct WebView: NSViewRepresentable {
                 })();
             """
 
-            webView.evaluateJavaScript(jsCode) { [weak self] result, _ in
+            webView.evaluateJavaScript(jsCode) { [weak self] result, error in
+                guard error == nil else {
+                    print("Error evaluating JavaScript for middle-click link detection: \(error!.localizedDescription)")
+                    return
+                }
+
                 if let urlString = result as? String, let url = URL(string: urlString),
-                   let tabManager = self?.tabManager, let historyManager = self?.historyManager
+                   let tabManager = self?.tabManager, let historyManager = self?.historyManager,
+                   ["http", "https"].contains(url.scheme?.lowercased() ?? "")
                 {
                     DispatchQueue.main.async {
                         tabManager.openTab(

--- a/ora/UI/WebView.swift
+++ b/ora/UI/WebView.swift
@@ -129,6 +129,7 @@ struct WebView: NSViewRepresentable {
                     tabManager.openTab(
                         url: url,
                         historyManager: historyManager,
+                        focusAfterOpening: false,
                         isPrivate: self?.privacyMode?.isPrivate ?? false
                     )
                 }


### PR DESCRIPTION
# Description

I added a new mouse event handler that allows users to open links on new tabs by using middle click. This is a feature I use daily and wanted to have in Ora.

I also modified the `openTab` method in the `TabManager` class to accept a new `focusAfterOpening` argument. This allows us to create new tabs without opening them right away.

https://github.com/user-attachments/assets/7215621a-3e21-46e3-863d-7518bf2ae86f

> NOTE: I asked Claude for the JS script to get the href of the middle-clicked element. After some testing, it seems and works great.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Middle-clicking a link now opens it in a new background tab without changing focus. Added an optional focusAfterOpening flag to TabManager.openTab to support background tab creation.

- **New Features**
  - Handle middle mouse button in WebView; find the clicked link and open it in a new tab with focusAfterOpening: false (respects private mode).
  - Keep existing behavior by default; new tab is only focused when focusAfterOpening is true.

<!-- End of auto-generated description by cubic. -->

