### PR TITLE
fix(browser): fixes sidebar behavior with downloads widgets when side…

### DIFF
--- a/ora/Services/FaviconService.swift
+++ b/ora/Services/FaviconService.swift
@@ -65,7 +65,7 @@ class FaviconService: ObservableObject {
 
     private func fetchFavicon(for domain: String, completion: @escaping (NSImage?) -> Void) {
         let faviconURLs = [
-             "https://www.google.com/s2/favicons?domain=\(domain)&sz=64",
+            "https://www.google.com/s2/favicons?domain=\(domain)&sz=64",
             "https://\(domain)/favicon.ico",
             "https://\(domain)/apple-touch-icon.png"
         ]


### PR DESCRIPTION
 # Fix: Sidebar auto-hide behavior with downloads popover

  This PR fixes an issue where the auto-hide sidebar would disappear when interacting with the downloads widget
  popover, making it impossible to interact with the downloads list.

  ## Problem

  When the sidebar is in auto-hide mode (hovering on the left edge):
  1. User hovers over the left edge to show the floating sidebar
  2. User clicks the download icon to open the downloads popover
  3. As soon as the mouse moves over the downloads popover, the sidebar disappears
  4. This causes the downloads popover to disappear as well, making it unusable

  ## Solution

  The fix implements intelligent hover tracking that:
  - Keeps the sidebar visible while the downloads popover is open
  - Only hides the sidebar when the popover closes AND the mouse is outside the sidebar area
  - Maintains natural sidebar behavior when the popover is closed by clicking the download icon (sidebar stays visible
   since user is still interacting with it)

  ## Changes Made

  - Added `DownloadManager` as an environment object to `BrowserView` to track popover state
  - Added `mouseIsOverSidebar` state to track actual mouse position
  - Modified the `MouseTrackingArea` binding to prevent hiding when downloads popover is open
  - Added `onChange` observer for `downloadManager.isDownloadsPopoverOpen` to handle sidebar visibility based on both
  popover state and mouse position

  ## Testing

  - ✅ Sidebar stays visible when downloads popover is open
  - ✅ Sidebar hides when clicking outside while popover is open
  - ✅ Sidebar stays visible when closing popover via download icon click
  - ✅ Normal hover behavior works when popover is not involved
  - ✅ No regressions in regular sidebar toggle functionality

  ## Media

  | Before | After |
 
 Before: 

https://github.com/user-attachments/assets/b82ca3a2-dcae-4c4d-a727-caa2560970eb

After:  

[sidebar-fix.webm](https://github.com/user-attachments/assets/e382659e-0d62-4284-81c9-e8a554c878c9)

 
 ## Checklist

  - [x] Code builds successfully
  - [x] Tests pass
  - [x] Code follows formatting standards (swiftformat/swiftlint)
  - [x] Descriptive title and description
  - [x] Screenshots/videos included
  - [x] No duplicate functionality
