### PR TITLE
Fix: prevent media player controls from expanding sidebar height

### DIFF
--- a/ora/Modules/Player/GlobalMediaPlayer.swift
+++ b/ora/Modules/Player/GlobalMediaPlayer.swift
@@ -74,18 +74,10 @@ private struct MediaPlayerCard: View {
                 .padding(.top, 6)
             }
 
-            HStack(spacing: 12) {
-                Button { tabManager.activateTab(id: session.tabID) } label: {
-                    faviconImage
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 18, height: 18)
-                        .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-                }
-                .buttonStyle(PlayerIconButtonStyle(isEnabled: true))
-                .help("Go to playing tab")
+            HStack(alignment: .center) {
+                faviconIcon
 
-                Spacer(minLength: 4)
+                Spacer()
 
                 Button(action: { media.previousTrack(session.tabID) }) {
                     Image(systemName: "backward.fill")
@@ -109,17 +101,9 @@ private struct MediaPlayerCard: View {
                 .buttonStyle(PlayerIconButtonStyle(isEnabled: media.canGoNext(of: session.tabID)))
                 .disabled(!media.canGoNext(of: session.tabID))
 
-                Spacer(minLength: 6)
+                Spacer()
 
-                Button {
-                    withAnimation(.easeOut(duration: 0.15)) { showVolume.toggle() }
-                } label: {
-                    Image(systemName: media
-                        .volume(of: session.tabID) <= 0.001 ? "speaker.slash.fill" : "speaker.wave.2.fill"
-                    )
-                    .font(.system(size: 12, weight: .semibold))
-                }
-                .buttonStyle(PlayerIconButtonStyle(isEnabled: true))
+                volumeButton
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 6)
@@ -146,5 +130,33 @@ private struct MediaPlayerCard: View {
         )
         .onHover { hovered = $0 }
         .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Favicon Icon
+
+    private var faviconIcon: some View {
+        Button { tabManager.activateTab(id: session.tabID) } label: {
+            faviconImage
+                .resizable()
+                .scaledToFit()
+                .frame(width: 18, height: 18)
+                .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        }
+        .buttonStyle(PlayerIconButtonStyle(isEnabled: true))
+        .help("Go to playing tab")
+    }
+
+    // MARK: - Volume Button
+
+    private var volumeButton: some View {
+        Button {
+            withAnimation(.easeOut(duration: 0.15)) { showVolume.toggle() }
+        } label: {
+            Image(systemName: media
+                .volume(of: session.tabID) <= 0.001 ? "speaker.slash.fill" : "speaker.wave.2.fill"
+            )
+            .font(.system(size: 12, weight: .semibold))
+        }
+        .buttonStyle(PlayerIconButtonStyle(isEnabled: true))
     }
 }

--- a/ora/Services/FaviconService.swift
+++ b/ora/Services/FaviconService.swift
@@ -65,7 +65,7 @@ class FaviconService: ObservableObject {
 
     private func fetchFavicon(for domain: String, completion: @escaping (NSImage?) -> Void) {
         let faviconURLs = [
-             "https://www.google.com/s2/favicons?domain=\(domain)&sz=64",
+            "https://www.google.com/s2/favicons?domain=\(domain)&sz=64",
             "https://\(domain)/favicon.ico",
             "https://\(domain)/apple-touch-icon.png"
         ]


### PR DESCRIPTION
I believe this fixes #94 

# Before And After

<img width="226" height="792" alt="Screenshot 2025-09-16 at 7 00 49 PM" src="https://github.com/user-attachments/assets/262745e3-153c-4162-a321-323ac7b90304" />



<img width="226" height="792" alt="Screenshot 2025-09-16 at 6 59 56 PM" src="https://github.com/user-attachments/assets/8d2ef626-d713-4800-9bc0-67b84b945897" />

