### PR TITLE
fix(tabs): keyboard shortcuts for tab selection

### DIFF
--- a/ora/Common/Constants/AppEvents.swift
+++ b/ora/Common/Constants/AppEvents.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
     static let nextTab = Notification.Name("NextTab")
     static let previousTab = Notification.Name("PreviousTab")
     static let toggleToolbar = Notification.Name("ToggleToolbar")
+    static let selectTabAtIndex = Notification.Name("SelectTabAtIndex") // userInfo: ["index": Int]
 
     // Per-window settings/events
     static let setAppearance = Notification.Name("SetAppearance") // userInfo: ["appearance": String]

--- a/ora/Models/Tab.swift
+++ b/ora/Models/Tab.swift
@@ -115,13 +115,9 @@ class Tab: ObservableObject, Identifiable {
 
         // Set up navigation delegate
 
-        // Load initial URL
-        DispatchQueue.main.async {
-            self.setupNavigationDelegate()
-            self.syncBackgroundColorFromHex()
-            self.webView.load(URLRequest(url: url))
-            self.isWebViewReady = true
-        }
+        // Don't automatically load URL - let TabManager handle it
+        // This prevents all tabs from loading on app launch
+        self.isWebViewReady = false
     }
 
     func syncBackgroundColorFromHex() {

--- a/ora/Modules/Browser/BrowserView.swift
+++ b/ora/Modules/Browser/BrowserView.swift
@@ -6,6 +6,8 @@ struct BrowserView: View {
     @Environment(\.theme) var theme
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var downloadManager: DownloadManager
+    @EnvironmentObject private var historyManager: HistoryManager
+    @EnvironmentObject private var privacyMode: PrivacyMode
     @State private var isFullscreen = false
     @State private var showFloatingSidebar = false
     @State private var isMouseOverSidebar = false
@@ -152,6 +154,19 @@ struct BrowserView: View {
                 } else if !isMouseOverSidebar {
                     // Hide sidebar when popover closes and mouse is not over sidebar
                     showFloatingSidebar = false
+                }
+            }
+        }
+        .onChange(of: tabManager.activeTab) { newTab in
+            // Restore tab state when switching tabs via keyboard shortcut
+            if let tab = newTab, !tab.isWebViewReady {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                    tab.restoreTransientState(
+                        historyManger: historyManager,
+                        downloadManager: downloadManager,
+                        tabManager: tabManager,
+                        isPrivate: privacyMode.isPrivate
+                    )
                 }
             }
         }

--- a/ora/OraCommands.swift
+++ b/ora/OraCommands.swift
@@ -96,6 +96,89 @@ struct OraCommands: Commands {
 
             Button("Next Tab") { NotificationCenter.default.post(name: .nextTab, object: NSApp.keyWindow) }
             Button("Previous Tab") { NotificationCenter.default.post(name: .previousTab, object: NSApp.keyWindow) }
+
+            Divider()
+
+            Button("Tab 1") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 1]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab1)
+
+            Button("Tab 2") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 2]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab2)
+
+            Button("Tab 3") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 3]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab3)
+
+            Button("Tab 4") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 4]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab4)
+
+            Button("Tab 5") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 5]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab5)
+
+            Button("Tab 6") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 6]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab6)
+
+            Button("Tab 7") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 7]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab7)
+
+            Button("Tab 8") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 8]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab8)
+
+            Button("Tab 9") {
+                NotificationCenter.default.post(
+                    name: .selectTabAtIndex,
+                    object: NSApp.keyWindow,
+                    userInfo: ["index": 9]
+                )
+            }
+            .keyboardShortcut(KeyboardShortcuts.Tabs.tab9)
         }
 
         CommandGroup(replacing: .toolbar) {

--- a/ora/OraRoot.swift
+++ b/ora/OraRoot.swift
@@ -177,6 +177,12 @@ struct OraRoot: View {
                     guard note.object as? NSWindow === window ?? NSApp.keyWindow else { return }
                     updateService.checkForUpdates()
                 }
+                NotificationCenter.default.addObserver(forName: .selectTabAtIndex, object: nil, queue: .main) { note in
+                    guard note.object as? NSWindow === window ?? NSApp.keyWindow else { return }
+                    if let index = note.userInfo?["index"] as? Int {
+                        tabManager.selectTabAtIndex(index)
+                    }
+                }
             }
     }
 }


### PR DESCRIPTION
# Fix Command + {number} Tab Switching and Improve Tab Loading Performance

 ## Summary

  This PR implements the missing Command+Number keyboard shortcuts for tab switching and fixes a performance issue
  where all tabs were loading their WebViews on browser launch, causing long loading times.

 ## Issues Fixed

  1. Command+Number shortcuts not working - Users heard a "donk" sound when pressing Command+1 through Command+9, indicating unhandled keyboard shortcuts
  2. Slow tab loading on browser launch - All persisted tabs were initializing WebViews on startup, causing
  performance issues

  ## Changes Made

  ### 1. Implemented Command+Number Tab Switching

  - Added notification support (AppEvents.swift):
    - Added selectTabAtIndex notification with index parameter
  - Added TabManager method (TabManager.swift):
    - Implemented selectTabAtIndex(_ index: Int) that matches the sidebar's visual ordering
    - Respects tab type hierarchy: Favorites → Pinned → Normal tabs
    - Command+9 selects the last tab (following standard browser conventions)
  - Added menu items (OraCommands.swift):
    - Added Command+1 through Command+9 menu items in the Tabs menu
    - Each shortcut posts the selectTabAtIndex notification with the appropriate index
  - Added notification observer (OraRoot.swift):
    - Listens for selectTabAtIndex notifications and calls the TabManager method

  ### 2. Fixed Tab Loading Performance

  - Modified Tab initialization (Tab.swift):
    - Removed automatic WebView loading in init method
    - Set isWebViewReady = false by default for lazy loading
  - Updated TabManager (TabManager.swift):
    - Fixed initializeActiveContainerAndTab to select the last accessed tab on launch
    - Added restoreTransientState calls when creating new tabs
  - Added automatic tab restoration (BrowserView.swift):
    - Added onChange handler for activeTab that restores tab state when switching
    - Ensures tabs load their WebViews only when activated

  ## Technical Details

  The implementation follows existing patterns in the codebase:
  - Uses the notification system for keyboard shortcuts
  - Maintains window-specific handling
  - Preserves lazy loading for better performance
  - Respects the sidebar's visual tab ordering

  ## Testing

  - ✅ Command+1 through Command+8 select the corresponding tab
  - ✅ Command+9 selects the last tab
  - ✅ Tab ordering matches the sidebar display
  - ✅ Only the active tab loads on browser launch
  - ✅ Tab switching via shortcuts is fast and responsive
  - ✅ New tabs load properly when created
  
  ## Media
  | Before | After |
  
  Before (unmute video sound): 
  
https://github.com/user-attachments/assets/cb7fe1e6-1ddf-4908-87d3-a0f2df78be42

  
<img width="657" height="452" alt="Screenshot 2025-09-18 at 09 49 54" src="https://github.com/user-attachments/assets/3c86b591-6fcb-47e5-a0d7-b958c12bb4bd" />

  After:  

https://github.com/user-attachments/assets/7f42d86a-6e60-4a4a-be0c-57e06728e162

<img width="652" height="407" alt="Screenshot 2025-09-18 at 09 49 38" src="https://github.com/user-attachments/assets/de49ec74-6c33-441d-9421-82a6baedc72f" />

  
   ## Checklist

  - [x] Code builds successfully
  - [x] Tests pass
  - [x] Code follows formatting standards (swiftformat/swiftlint)
  - [x] Descriptive title and description
  - [x] Screenshots/videos included
  - [x] No duplicate functionality
