### PR TITLE
Add horizontal padding to search bar in LauncherMain SwiftUI view

### DIFF
--- a/ora/Modules/Launcher/Main/LauncherMain.swift
+++ b/ora/Modules/Launcher/Main/LauncherMain.swift
@@ -357,6 +357,7 @@ struct LauncherMain: View {
             color: Color.black.opacity(0.1),
             radius: 40, x: 0, y: 24
         )
+        .padding(.horizontal, 20) // Add horizontal margins around the entire search bar
     }
 
     private func getPlaceholder(match: Match?) -> String {


### PR DESCRIPTION
This is a little fix i made to the UI, because it was bugging me too much.

A thin window will not cause the search bar to stick to the edges anymore.


<img width="876" height="1096" alt="Screenshot 2025-09-19 at 11 41 48" src="https://github.com/user-attachments/assets/fe9389f8-1df7-483d-b478-a5a5a58f34d5" />
<img width="1768" height="1097" alt="Screenshot 2025-09-19 at 11 42 05" src="https://github.com/user-attachments/assets/be101fb1-fe0f-4d5c-abd2-b5725f2ca93b" />
