### PR TITLE
Fix appearance update crash

### DIFF
--- a/ora/Services/AppearanceManager.swift
+++ b/ora/Services/AppearanceManager.swift
@@ -24,13 +24,17 @@ class AppearanceManager: ObservableObject {
     }
 
     func updateAppearance() {
+        guard NSApp != nil else {
+            print("NSApp is nil, skipping appearance update")
+            return
+        }
         switch appearance {
-        case .system:
-            NSApp.appearance = nil
-        case .light:
-            NSApp.appearance = NSAppearance(named: .aqua)
-        case .dark:
-            NSApp.appearance = NSAppearance(named: .darkAqua)
+            case .system:
+                NSApp.appearance = nil
+            case .light:
+                NSApp.appearance = NSAppearance(named: .aqua)
+            case .dark:
+                NSApp.appearance = NSAppearance(named: .darkAqua)
         }
     }
 }

--- a/ora/oraApp.swift
+++ b/ora/oraApp.swift
@@ -7,6 +7,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Disable automatic window tabbing for all NSWindow instances
         NSWindow.allowsAutomaticWindowTabbing = false
+        AppearanceManager.shared.updateAppearance()
     }
 }
 


### PR DESCRIPTION
## Summary
- Prevent crash in AppearanceManager when NSApp is nil during app launch
- Add guard check and call updateAppearance in AppDelegate

Fixes #90 
Fixes #107 