### PR TITLE
ux: Split AI & classic search engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 # XcodeGen
 project.yml.lock
 
+# Xcode Build Server
+buildServer.json
+
 # Swift Package Manager
 .swiftpm/
 Package.resolved
@@ -43,6 +46,7 @@ Temporary Items
 # IDE
 .vscode/
 .idea/
+.zed/
 
 # Build directory (allow directory but ignore contents)
 build/*

--- a/ora/Modules/Settings/Sections/SearchEngineSettingsView.swift
+++ b/ora/Modules/Settings/Sections/SearchEngineSettingsView.swift
@@ -115,20 +115,63 @@ struct SearchEngineSettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
-                        // Built-in search engines
-                        ForEach(searchEngineService.builtInSearchEngines, id: \.name) { engine in
-                            BuiltInSearchEngineRow(
-                                engine: engine,
-                                isDefault: settings.globalDefaultSearchEngine == engine
-                                    .name || (settings.globalDefaultSearchEngine == nil && engine.name == "Google"),
-                                onSetAsDefault: {
-                                    if engine.name == "Google" {
-                                        settings.globalDefaultSearchEngine = nil
-                                    } else {
-                                        settings.globalDefaultSearchEngine = engine.name
+                        // Conventional Search Engines
+                        let conventionalEngines = searchEngineService.builtInSearchEngines.filter {
+                            !$0.isAIChat
+                        }
+                        if !conventionalEngines.isEmpty {
+                            Text("Conventional Search Engines")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(.bottom, 4)
+
+                            ForEach(conventionalEngines, id: \.name) { engine in
+                                BuiltInSearchEngineRow(
+                                    engine: engine,
+                                    isDefault: settings.globalDefaultSearchEngine
+                                        == engine
+                                        .name
+                                        || (settings.globalDefaultSearchEngine == nil
+                                            && engine.name == "Google"
+                                        ),
+                                    onSetAsDefault: {
+                                        if engine.name == "Google" {
+                                            settings.globalDefaultSearchEngine = nil
+                                        } else {
+                                            settings.globalDefaultSearchEngine = engine.name
+                                        }
                                     }
-                                }
-                            )
+                                )
+                            }
+                        }
+
+                        // AI Search Engines
+                        let aiEngines = searchEngineService.builtInSearchEngines.filter(\.isAIChat)
+                        if !aiEngines.isEmpty {
+                            Text("AI Search Engines")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(.top, 8)
+                                .padding(.bottom, 4)
+
+                            ForEach(aiEngines, id: \.name) { engine in
+                                BuiltInSearchEngineRow(
+                                    engine: engine,
+                                    isDefault: settings.globalDefaultSearchEngine
+                                        == engine
+                                        .name
+                                        || (settings.globalDefaultSearchEngine == nil
+                                            && engine.name == "Google"
+                                        ),
+                                    onSetAsDefault: {
+                                        if engine.name == "Google" {
+                                            settings.globalDefaultSearchEngine = nil
+                                        } else {
+                                            settings.globalDefaultSearchEngine = engine.name
+                                        }
+                                    }
+                                )
+                            }
                         }
 
                         if !settings.customSearchEngines.isEmpty {
@@ -237,16 +280,6 @@ struct BuiltInSearchEngineRow: View {
             HStack(spacing: 8) {
                 Text(engine.name)
                     .font(.body)
-
-                if engine.isAIChat {
-                    Text("AI")
-                        .font(.caption)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Color.purple.opacity(0.2))
-                        .foregroundColor(.purple)
-                        .cornerRadius(4)
-                }
 
                 if isDefault {
                     Text("Default")

--- a/ora/Services/AppearanceManager.swift
+++ b/ora/Services/AppearanceManager.swift
@@ -29,12 +29,12 @@ class AppearanceManager: ObservableObject {
             return
         }
         switch appearance {
-            case .system:
-                NSApp.appearance = nil
-            case .light:
-                NSApp.appearance = NSAppearance(named: .aqua)
-            case .dark:
-                NSApp.appearance = NSAppearance(named: .darkAqua)
+        case .system:
+            NSApp.appearance = nil
+        case .light:
+            NSApp.appearance = NSAppearance(named: .aqua)
+        case .dark:
+            NSApp.appearance = NSAppearance(named: .darkAqua)
         }
     }
 }

--- a/ora/Services/SearchEngineService.swift
+++ b/ora/Services/SearchEngineService.swift
@@ -81,6 +81,30 @@ class SearchEngineService: ObservableObject {
                 autoSuggestions: self.googleSuggestions
             ),
             SearchEngine(
+                name: "DuckDuckGo",
+                color: Color(hex: "#DE5833"),
+                icon: "",
+                aliases: ["duckduckgo", "ddg", "duck"],
+                searchURL: "https://duckduckgo.com/?q={query}",
+                isAIChat: false
+            ),
+            SearchEngine(
+                name: "Kagi",
+                color: Color(hex: "#4A90E2"),
+                icon: "",
+                aliases: ["kagi", "kg"],
+                searchURL: "https://kagi.com/search?q={query}",
+                isAIChat: false
+            ),
+            SearchEngine(
+                name: "Bing",
+                color: Color(hex: "#00809D"),
+                icon: "",
+                aliases: ["bing", "b", "microsoft"],
+                searchURL: "https://www.bing.com/search?q={query}",
+                isAIChat: false
+            ),
+            SearchEngine(
                 name: "Grok",
                 color: theme?.foreground ?? .white,
                 icon: "grok-capsule-logo",


### PR DESCRIPTION
- also adds duck duck go, bing, & kagi

<img width="1332" height="936" alt="Screenshot 2025-09-21 at 2 02 17 PM" src="https://github.com/user-attachments/assets/921f2055-dcfc-4714-8844-ce66dcfe76a4" />

> sorry about the prior PR weird behaviour when committing was auto staging other files so just setup a proper gitignore for people outside xcode as this should now avoid trying to commit files for zed & vscode with xcode-build-server now.