### PR TITLE
ux: Improve page finder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 # XcodeGen
 project.yml.lock
 
+# Xcode Build Server
+buildServer.json
+
 # Swift Package Manager
 .swiftpm/
 Package.resolved
@@ -43,6 +46,7 @@ Temporary Items
 # IDE
 .vscode/
 .idea/
+.zed/
 
 # Build directory (allow directory but ignore contents)
 build/*

--- a/ora/Modules/Find/FindView.swift
+++ b/ora/Modules/Find/FindView.swift
@@ -30,8 +30,8 @@ struct FindView: View {
             navigationButtons
             closeButton
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
         .background(backgroundView)
         .overlay(borderView)
         .shadow(
@@ -87,6 +87,24 @@ struct FindView: View {
                 }
                 return .handled
             }
+            .onKeyPress(.upArrow) {
+                Task { @MainActor in
+                    if !searchText.isEmpty, matchCount > 0 {
+                        controller.previousMatch()
+                        updateCurrentMatch()
+                    }
+                }
+                return .handled
+            }
+            .onKeyPress(.downArrow) {
+                Task { @MainActor in
+                    if !searchText.isEmpty, matchCount > 0 {
+                        controller.nextMatch()
+                        updateCurrentMatch()
+                    }
+                }
+                return .handled
+            }
     }
 
     @ViewBuilder
@@ -125,7 +143,7 @@ struct FindView: View {
                     .padding(.vertical, 4)
             }
         }
-        .frame(minWidth: 80) // Fixed minimum width
+        .frame(minWidth: 80)  // Fixed minimum width
     }
 
     @ViewBuilder
@@ -134,21 +152,23 @@ struct FindView: View {
             Text("\(currentMatch)")
                 .font(.system(size: 12, weight: .bold))
                 .foregroundColor(theme.foreground)
-                .monospacedDigit() // Prevents width changes when numbers change
+                .monospacedDigit()  // Prevents width changes when numbers change
             Text("/")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(theme.foreground.opacity(0.8))
             Text("\(matchCount)")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundColor(theme.foreground.opacity(0.9))
-                .monospacedDigit() // Prevents width changes when numbers change
+                .monospacedDigit()  // Prevents width changes when numbers change
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(BlurEffectView(
-            material: .popover,
-            blendingMode: .withinWindow
-        ))
+        .background(
+            BlurEffectView(
+                material: .popover,
+                blendingMode: .withinWindow
+            )
+        )
         .cornerRadius(6)
     }
 
@@ -159,10 +179,12 @@ struct FindView: View {
             .foregroundColor(theme.foreground)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(BlurEffectView(
-                material: .popover,
-                blendingMode: .withinWindow
-            ))
+            .background(
+                BlurEffectView(
+                    material: .popover,
+                    blendingMode: .withinWindow
+                )
+            )
             .cornerRadius(6)
     }
 
@@ -189,10 +211,12 @@ struct FindView: View {
                 .frame(width: 28, height: 28)
         }
         .disabled(searchText.isEmpty || matchCount == 0)
-        .buttonStyle(EnhancedFindButtonStyle(
-            colorScheme: colorScheme,
-            isEnabled: !(searchText.isEmpty || matchCount == 0)
-        ))
+        .buttonStyle(
+            EnhancedFindButtonStyle(
+                colorScheme: colorScheme,
+                isEnabled: !(searchText.isEmpty || matchCount == 0)
+            )
+        )
     }
 
     @ViewBuilder
@@ -208,10 +232,12 @@ struct FindView: View {
                 .frame(width: 28, height: 28)
         }
         .disabled(searchText.isEmpty || matchCount == 0)
-        .buttonStyle(EnhancedFindButtonStyle(
-            colorScheme: colorScheme,
-            isEnabled: !(searchText.isEmpty || matchCount == 0)
-        ))
+        .buttonStyle(
+            EnhancedFindButtonStyle(
+                colorScheme: colorScheme,
+                isEnabled: !(searchText.isEmpty || matchCount == 0)
+            )
+        )
     }
 
     @ViewBuilder

--- a/ora/Services/AppearanceManager.swift
+++ b/ora/Services/AppearanceManager.swift
@@ -29,12 +29,12 @@ class AppearanceManager: ObservableObject {
             return
         }
         switch appearance {
-            case .system:
-                NSApp.appearance = nil
-            case .light:
-                NSApp.appearance = NSAppearance(named: .aqua)
-            case .dark:
-                NSApp.appearance = NSAppearance(named: .darkAqua)
+        case .system:
+            NSApp.appearance = nil
+        case .light:
+            NSApp.appearance = NSAppearance(named: .aqua)
+        case .dark:
+            NSApp.appearance = NSAppearance(named: .darkAqua)
         }
     }
 }


### PR DESCRIPTION
- shrinks down the large paddings 
- binds up and down arrows to the `searchTextField` making it fully keyboard navigable

<img width="1353" height="949" alt="Screenshot 2025-09-21 at 3 14 38 PM" src="https://github.com/user-attachments/assets/40859e1e-c476-4320-8fc2-cc6eff98248d" />
