### PR TITLE
fix: move to container shows proper containers now

### DIFF
--- a/ora/UI/TabItem.swift
+++ b/ora/UI/TabItem.swift
@@ -208,23 +208,21 @@ struct TabItem: View {
             )
         }
 
-        Divider()
+        if availableContainers.count > 1 {
+            Divider()
 
-        Menu("Move to Container") {
-            ForEach(availableContainers) { container in
-                if tab.container.id != tabManager.activeContainer?.id {
-                    Button(action: { onMoveToContainer(tab.container) }) {
-                        Label {
-                            Text(container.name)
-                        } icon: {
-                            Text(container.emoji) // This is where you show the emoji
+            Menu("Move to Container") {
+                ForEach(availableContainers) { container in
+                    if tab.container.id != container.id {
+                        Button(action: { onMoveToContainer(container) }) {
+                            Text(container.emoji.isEmpty ? container.name : "\(container.emoji) \(container.name)")
                         }
                     }
                 }
             }
-        }
 
-        Divider()
+            Divider()
+        }
 
         Button(role: .destructive, action: onClose) {
             Label("Close Tab", systemImage: "xmark")


### PR DESCRIPTION
## Fix "Move to Container" context menu functionality

**Context menu not showing containers:**
- Fixed condition that was incorrectly comparing against `activeContainer` instead of checking if each container differs from the tab's current container
- Fixed action callback that was passing the tab's current container instead of the target container

**Emoji display in context menu:**
- Replaced `Label` with custom text icons (which don't render properly in macOS context menus) with simple string interpolation
- Made emoji display conditional - only shows if container has an emoji set

**UX improvements:**
- Hide "Move to Container" option entirely when only one container exists
- Clean up dividers to avoid orphaned separators

## Before

https://github.com/user-attachments/assets/585cd946-935a-4394-ba29-156a7c621123

## After

https://github.com/user-attachments/assets/fb466b9b-34aa-46e4-b4f5-261e67092d7e