### PR TITLE
feat: add URL handling and deep linking support

### DIFF
--- a/ora/Common/Constants/AppEvents.swift
+++ b/ora/Common/Constants/AppEvents.swift
@@ -21,4 +21,7 @@ extension Notification.Name {
     // Per-window settings/events
     static let setAppearance = Notification.Name("SetAppearance") // userInfo: ["appearance": String]
     static let checkForUpdates = Notification.Name("CheckForUpdates")
+
+    // AppDelegate → UI routing
+    static let openURL = Notification.Name("OpenURL") // userInfo: ["url": URL]
 }

--- a/ora/Common/Utils/WindowFactory.swift
+++ b/ora/Common/Utils/WindowFactory.swift
@@ -1,0 +1,26 @@
+import AppKit
+import SwiftUI
+
+enum WindowFactory {
+    static func makeMainWindow(rootView: some View = OraRoot(), size: CGSize = CGSize(width: 1440, height: 900)) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: size.width, height: size.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isReleasedWhenClosed = false
+
+        let hostingController = NSHostingController(rootView: rootView)
+        window.contentViewController = hostingController
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        return window
+    }
+}
+
+
+

--- a/ora/Common/Utils/WindowFactory.swift
+++ b/ora/Common/Utils/WindowFactory.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 enum WindowFactory {
-    static func makeMainWindow(rootView: some View = OraRoot(), size: CGSize = CGSize(width: 1440, height: 900)) -> NSWindow {
+    static func makeMainWindow(rootView: some View, size: CGSize = CGSize(width: 1440, height: 900)) -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: size.width, height: size.height),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],

--- a/ora/Info.plist
+++ b/ora/Info.plist
@@ -16,6 +16,18 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>Ora Browser</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>http</string>
+				<string>https</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>SUEnableAutomaticChecks</key>

--- a/ora/Info.plist
+++ b/ora/Info.plist
@@ -4,6 +4,45 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Web URL</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.url</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>HTML document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.html</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>XHTML document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.xhtml</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -19,6 +58,8 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
 			<key>CFBundleURLName</key>
 			<string>Ora Browser</string>
 			<key>CFBundleURLSchemes</key>
@@ -26,10 +67,20 @@
 				<string>http</string>
 				<string>https</string>
 			</array>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.web-browser</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>NSUserActivityTypeBrowsingWeb</string>
+	</array>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/ora/Modules/Settings/Sections/GeneralSettingsView.swift
+++ b/ora/Modules/Settings/Sections/GeneralSettingsView.swift
@@ -5,6 +5,7 @@ struct GeneralSettingsView: View {
     @EnvironmentObject var appearanceManager: AppearanceManager
     @EnvironmentObject var updateService: UpdateService
     @StateObject private var settings = SettingsStore.shared
+    @StateObject private var defaultBrowserManager = DefaultBrowserManager.shared
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -30,7 +31,7 @@ struct GeneralSettingsView: View {
                     .background(theme.solidWindowBackgroundColor)
                     .cornerRadius(8)
                     
-                    if !DefaultBrowserManager.isDefault {
+                     if !defaultBrowserManager.isDefault {
                         
                         HStack {
                             Text("Born for your Mac. Make Ora your default browser.")

--- a/ora/Modules/Settings/Sections/GeneralSettingsView.swift
+++ b/ora/Modules/Settings/Sections/GeneralSettingsView.swift
@@ -29,16 +29,19 @@ struct GeneralSettingsView: View {
                     .padding(12)
                     .background(theme.solidWindowBackgroundColor)
                     .cornerRadius(8)
-
-                    HStack {
-                        Text("Born for your Mac. Make Ora your default browser.")
-                        Spacer()
-                        Button("Set Ora as default") { openDefaultBrowserSettings() }
+                    
+                    if !DefaultBrowserManager.isDefault {
+                        
+                        HStack {
+                            Text("Born for your Mac. Make Ora your default browser.")
+                            Spacer()
+                            Button("Set Ora as default") { DefaultBrowserManager.requestSetAsDefault() }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(8)
+                        .background(theme.solidWindowBackgroundColor)
+                        .cornerRadius(8)
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(8)
-                    .background(theme.solidWindowBackgroundColor)
-                    .cornerRadius(8)
 
                     AppearanceSelector(selection: $appearanceManager.appearance)
 
@@ -92,15 +95,6 @@ struct GeneralSettingsView: View {
                 }
             }
         }
-    }
-
-    private func openDefaultBrowserSettings() {
-        guard
-            let url = URL(
-                string: "x-apple.systempreferences:com.apple.preference.general?DefaultWebBrowser"
-            )
-        else { return }
-        NSWorkspace.shared.open(url)
     }
 
     private func getAppVersion() -> String {

--- a/ora/OraRoot.swift
+++ b/ora/OraRoot.swift
@@ -177,6 +177,22 @@ struct OraRoot: View {
                         tabManager.selectTabAtIndex(index)
                     }
                 }
+                NotificationCenter.default.addObserver(forName: .openURL, object: nil, queue: .main) { note in
+                    let targetWindow = window ?? NSApp.keyWindow
+                    if let sender = note.object as? NSWindow {
+                        guard sender === targetWindow else { return }
+                    } else {
+                        guard NSApp.keyWindow === targetWindow else { return }
+                    }
+                    guard let url = note.userInfo?["url"] as? URL else { return }
+                    tabManager.openTab(
+                        url: url,
+                        historyManager: historyManager,
+                        downloadManager: downloadManager,
+                        focusAfterOpening: true,
+                        isPrivate: privacyMode.isPrivate
+                    )
+                }
             }
     }
 }

--- a/ora/Services/DefaultBrowserManager.swift
+++ b/ora/Services/DefaultBrowserManager.swift
@@ -8,18 +8,43 @@
 
 import CoreServices
 import AppKit
+import Combine
 
-enum DefaultBrowserManager {
-    static var isDefault: Bool {
+class DefaultBrowserManager: ObservableObject {
+    static let shared = DefaultBrowserManager()
+
+    @Published var isDefault: Bool = false
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private init() {
+        updateIsDefault()
+        // Periodically check if default browser status changed. I couldn't find another way.
+        Timer.publish(every: 1.0, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.updateIsDefault()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateIsDefault() {
+        let newValue = Self.checkIsDefault()
+        if newValue != isDefault {
+            isDefault = newValue
+        }
+    }
+
+    static func checkIsDefault() -> Bool {
         guard let testURL = URL(string: "http://example.com"),
               let appURL = NSWorkspace.shared.urlForApplication(toOpen: testURL),
               let appBundle = Bundle(url: appURL) else {
             return false
         }
-        
+
         return appBundle.bundleIdentifier == Bundle.main.bundleIdentifier
     }
-    
+
     static func requestSetAsDefault() {
         let bundleID = Bundle.main.bundleIdentifier! as CFString
         LSSetDefaultHandlerForURLScheme("http" as CFString, bundleID)

--- a/ora/Services/DefaultBrowserManager.swift
+++ b/ora/Services/DefaultBrowserManager.swift
@@ -1,0 +1,28 @@
+//
+//  DefaultBrowserManager.swift
+//  ora
+//
+//  Created by keni on 9/30/25.
+//
+
+
+import CoreServices
+import AppKit
+
+enum DefaultBrowserManager {
+    static var isDefault: Bool {
+        guard let testURL = URL(string: "http://example.com"),
+              let appURL = NSWorkspace.shared.urlForApplication(toOpen: testURL),
+              let appBundle = Bundle(url: appURL) else {
+            return false
+        }
+        
+        return appBundle.bundleIdentifier == Bundle.main.bundleIdentifier
+    }
+    
+    static func requestSetAsDefault() {
+        let bundleID = Bundle.main.bundleIdentifier! as CFString
+        LSSetDefaultHandlerForURLScheme("http" as CFString, bundleID)
+        LSSetDefaultHandlerForURLScheme("https" as CFString, bundleID)
+    }
+}

--- a/ora/oraApp.swift
+++ b/ora/oraApp.swift
@@ -68,6 +68,7 @@ struct OraApp: App {
         WindowGroup(id: "normal") {
             OraRoot()
                 .frame(minWidth: 500, minHeight: 360)
+                .environmentObject(DefaultBrowserManager.shared)
         }
         .defaultSize(width: 1440, height: 900)
         .windowStyle(.hiddenTitleBar)
@@ -77,6 +78,7 @@ struct OraApp: App {
         WindowGroup("Private", id: "private") {
             OraRoot(isPrivate: true)
                 .frame(minWidth: 500, minHeight: 360)
+                .environmentObject(DefaultBrowserManager.shared)
         }
         .defaultSize(width: 1440, height: 900)
         .windowStyle(.hiddenTitleBar)
@@ -88,6 +90,7 @@ struct OraApp: App {
                 SettingsContentView()
                     .environmentObject(AppearanceManager.shared)
                     .environmentObject(UpdateService.shared)
+                    .environmentObject(DefaultBrowserManager.shared)
                     .withTheme()
                     .modelContainer(sharedModelContainer)
             } else {

--- a/ora/oraApp.swift
+++ b/ora/oraApp.swift
@@ -20,7 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             any.makeKeyAndOrderFront(nil)
             return any
         }
-        return WindowFactory.makeMainWindow()
+        return WindowFactory.makeMainWindow(rootView: OraRoot())
     }
     func handleIncomingURLs(_ urls: [URL]) {
         let window = getWindow()!

--- a/ora/oraApp.swift
+++ b/ora/oraApp.swift
@@ -9,6 +9,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSWindow.allowsAutomaticWindowTabbing = false
         AppearanceManager.shared.updateAppearance()
     }
+    func application(_ application: NSApplication, open urls: [URL]) {
+        handleIncomingURLs(urls)
+    }
+
+    func getWindow() -> NSWindow? {
+        if let key = NSApp.keyWindow { return key }
+        if let visible = NSApp.windows.first(where: { $0.isVisible }) { return visible }
+        if let any = NSApp.windows.first {
+            any.makeKeyAndOrderFront(nil)
+            return any
+        }
+        return WindowFactory.makeMainWindow()
+    }
+    func handleIncomingURLs(_ urls: [URL]) {
+        let window = getWindow()!
+        for url in urls {
+            let userInfo: [AnyHashable: Any] = ["url": url]
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .openURL, object: window, userInfo: userInfo)
+            }
+        }
+    }
 }
 
 extension Notification.Name {}
@@ -18,7 +40,6 @@ func deleteSwiftDataStore(_ loc: String) {
     let storeURL = URL.applicationSupportDirectory.appending(path: loc)
     let shmURL = storeURL.appendingPathExtension("-shm")
     let walURL = storeURL.appendingPathExtension("-wal")
-
     try? fileManager.removeItem(at: storeURL)
     try? fileManager.removeItem(at: shmURL)
     try? fileManager.removeItem(at: walURL)
@@ -38,11 +59,11 @@ class AppState: ObservableObject {
 @main
 struct OraApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-
+    
     // Shared model container that uses the same configuration as the main browser
     private let sharedModelContainer: ModelContainer? =
-        try? ModelConfiguration.createOraContainer(isPrivate: false)
-
+    try? ModelConfiguration.createOraContainer(isPrivate: false)
+    
     var body: some Scene {
         WindowGroup(id: "normal") {
             OraRoot()
@@ -51,7 +72,8 @@ struct OraApp: App {
         .defaultSize(width: 1440, height: 900)
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize)
-
+        .handlesExternalEvents(matching: [])
+        
         WindowGroup("Private", id: "private") {
             OraRoot(isPrivate: true)
                 .frame(minWidth: 500, minHeight: 360)
@@ -59,7 +81,8 @@ struct OraApp: App {
         .defaultSize(width: 1440, height: 900)
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize)
-
+        .handlesExternalEvents(matching: [])
+        
         Settings {
             if let sharedModelContainer {
                 SettingsContentView()

--- a/project.yml
+++ b/project.yml
@@ -49,6 +49,11 @@ targets:
         SUFeedURL: "https://the-ora.github.io/browser/appcast.xml"
         SUPublicEDKey: "Ozj+rezzbJAD76RfajtfQ7rFojJbpFSCl/0DcFSBCTI="
         SUEnableAutomaticChecks: YES
+        CFBundleURLTypes:
+          - CFBundleURLName: Ora Browser
+            CFBundleURLSchemes:
+              - http
+              - https
         
     entitlements:
       path: ora/ora.entitlements

--- a/project.yml
+++ b/project.yml
@@ -51,9 +51,31 @@ targets:
         SUEnableAutomaticChecks: YES
         CFBundleURLTypes:
           - CFBundleURLName: Ora Browser
+            CFBundleTypeRole: Editor
+            LSHandlerRank: Owner
             CFBundleURLSchemes:
               - http
               - https
+        CFBundleDocumentTypes:
+          - CFBundleTypeName: Web URL
+            CFBundleTypeRole: Viewer
+            LSHandlerRank: Owner
+            LSItemContentTypes:
+              - public.url
+          - CFBundleTypeName: HTML document
+            CFBundleTypeRole: Viewer
+            LSHandlerRank: Default
+            LSItemContentTypes:
+              - public.html
+          - CFBundleTypeName: XHTML document
+            CFBundleTypeRole: Viewer
+            LSHandlerRank: Default
+            LSItemContentTypes:
+              - public.xhtml
+        NSUserActivityTypes:
+          - NSUserActivityTypeBrowsingWeb
+        LSMinimumSystemVersion: "13.0"
+        LSApplicationCategoryType: public.app-category.web-browser
         
     entitlements:
       path: ora/ora.entitlements


### PR DESCRIPTION
Fixes #131 

## Summary
- Implemented URL scheme handling in the app to allow opening URLs directly.
- Added CFBundleURLTypes to project configuration for http and https schemes.
- Enhanced AppDelegate to manage incoming URLs and notify the UI.
- Updated OraRoot to handle URL opening via notifications.