### PR TITLE
Fixes issues with extensions

### DIFF
--- a/ora/Modules/Browser/BrowserView.swift
+++ b/ora/Modules/Browser/BrowserView.swift
@@ -20,6 +20,7 @@ struct BrowserView: View {
             sidebarVisibility.toggle(.primary)
         }
     }
+
     private func printExtensionInfo() {
         if let tab = tabManager.activeTab {
             if let controller = tab.webView.configuration.webExtensionController {
@@ -29,14 +30,17 @@ struct BrowserView: View {
                 for extCtx in controller.extensionContexts {
                     print("🔥 Extension Context Properties:")
                     print("  baseURL: \(extCtx.baseURL)")
-                    print("  commands: \(extCtx.commands.map { $0.id })")
+                    print("  commands: \(extCtx.commands.map(\.id))")
                     print("  currentPermissionMatchPatterns: \(extCtx.currentPermissionMatchPatterns)")
-                    print("  currentPermissions: \(extCtx.currentPermissions.map { $0.rawValue })")
+                    print("  currentPermissions: \(extCtx.currentPermissions.map(\.rawValue))")
                     print("  deniedPermissionMatchPatterns: \(extCtx.deniedPermissionMatchPatterns)")
                     print("  deniedPermissions: \(extCtx.deniedPermissions.map { "\($0.key.rawValue): \($0.value)" })")
-                    print("  errors: \(extCtx.errors.map { $0.localizedDescription })")
-                    print("  grantedPermissionMatchPatterns: \(extCtx.grantedPermissionMatchPatterns.map { "\($0.key): \($0.value)" })")
-                    print("  grantedPermissions: \(extCtx.grantedPermissions.map { "\($0.key.rawValue): \($0.value)" })")
+                    print("  errors: \(extCtx.errors.map(\.localizedDescription))")
+                    print(
+                        "  grantedPermissionMatchPatterns: \(extCtx.grantedPermissionMatchPatterns.map { "\($0.key): \($0.value)" })"
+                    )
+                    print("  grantedPermissions: \(extCtx.grantedPermissions.map { "\($0.key.rawValue): \($0.value)" })"
+                    )
                     print("  hasAccessToAllHosts: \(extCtx.hasAccessToAllHosts)")
                     print("  hasAccessToAllURLs: \(extCtx.hasAccessToAllURLs)")
                     print("  hasAccessToPrivateData: \(extCtx.hasAccessToPrivateData)")
@@ -62,10 +66,9 @@ struct BrowserView: View {
                     print("    Display Version: \(ext.displayVersion ?? "None")")
                     print("    Display Description: \(ext.displayDescription ?? "None")")
                     //                            print("    Permissions: \(ext.permissions.map { $0.rawValue })")
-                    //                            print("    Background Content URL: \(ext.backgroundContentURL?.absoluteString ?? "None")")
+                    //                            print("    Background Content URL:
+                    //                            \(ext.backgroundContentURL?.absoluteString ?? "None")")
                     //                            print("    Content Scripts Count: \(ext.contentScripts.count)")
-                    
-                    
                 }
             }
         }
@@ -94,7 +97,7 @@ struct BrowserView: View {
                     }
                 }
             )
-           
+
             .hide(sidebarVisibility)
             .splitter { Splitter.invisible() }
             .fraction(sidebarFraction)
@@ -132,7 +135,6 @@ struct BrowserView: View {
                     FloatingTabSwitcher()
                 }
             }
-           
 
             if sidebarVisibility.side == .primary {
                 // Floating sidebar with resizable width based on persisted fraction

--- a/ora/OraRoot.swift
+++ b/ora/OraRoot.swift
@@ -71,7 +71,6 @@ struct OraRoot: View {
     }
 
     var body: some View {
-
         BrowserView()
             .background(WindowReader(window: $window))
             .environment(\.window, window)

--- a/ora/Services/TabManager.swift
+++ b/ora/Services/TabManager.swift
@@ -387,7 +387,7 @@ class TabManager: ObservableObject {
         activeContainer = tab.container
         tab.container.lastAccessedAt = Date()
         tab.updateHeaderColor()
-       
+
         try? modelContext.save()
     }
 

--- a/ora/Services/TabScriptHandler.swift
+++ b/ora/Services/TabScriptHandler.swift
@@ -103,9 +103,8 @@ class TabScriptHandler: NSObject, WKScriptMessageHandler {
                 forIdentifier: containerId
             )
         }
-      
+
         configuration.webExtensionController = OraExtensionManager.shared.controller
-        
 
         // Performance optimizations
         configuration.allowsAirPlayForMediaPlayback = true
@@ -119,7 +118,7 @@ class TabScriptHandler: NSObject, WKScriptMessageHandler {
 //        if #unavailable(macOS 10.12) {
 //            // Picture in picture not available on older macOS versions
 //        } else {
-////            configuration.allowsPictureInPictureMediaPlaybook = true
+        ////            configuration.allowsPictureInPictureMediaPlaybook = true
 //        }
 
         // Enable media playback without user interaction
@@ -146,7 +145,8 @@ class TabScriptHandler: NSObject, WKScriptMessageHandler {
 
         // Download the file
         guard let (data, response) = try? await URLSession.shared.data(from: url),
-              let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+              let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200
+        else {
             logger.error("Failed to download extension")
             return
         }
@@ -157,7 +157,8 @@ class TabScriptHandler: NSObject, WKScriptMessageHandler {
         try? data.write(to: tempZipURL)
 
         // Extract
-        let extensionsDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("extensions")
+        let extensionsDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("extensions")
         if !FileManager.default.fileExists(atPath: extensionsDir.path) {
             try? FileManager.default.createDirectory(at: extensionsDir, withIntermediateDirectories: true)
         }

--- a/ora/Services/WebViewNavigationDelegate.swift
+++ b/ora/Services/WebViewNavigationDelegate.swift
@@ -1,8 +1,8 @@
 import AppKit
+import Foundation
 import os.log
 import SwiftUI
 @preconcurrency import WebKit
-import Foundation
 
 private let logger = Logger(subsystem: "com.orabrowser.ora", category: "WebViewNavigationDelegate")
 
@@ -252,11 +252,11 @@ class WebViewNavigationDelegate: NSObject, WKNavigationDelegate {
                 """
             )
         if navigationAction.modifierFlags.contains(.command),
-            let url = navigationAction.request.url,
-            let tab = self.tab,
-            let tabManager = tab.tabManager,
-            let historyManager = tab.historyManager,
-            let downloadManager = tab.downloadManager
+           let url = navigationAction.request.url,
+           let tab = self.tab,
+           let tabManager = tab.tabManager,
+           let historyManager = tab.historyManager,
+           let downloadManager = tab.downloadManager
         {
             // Open link in new tab
             DispatchQueue.main.async {
@@ -272,8 +272,6 @@ class WebViewNavigationDelegate: NSObject, WKNavigationDelegate {
             decisionHandler(.cancel)
             return
         }
-
-
 
         // Allow normal navigation
         decisionHandler(.allow)
@@ -454,7 +452,8 @@ class WebViewNavigationDelegate: NSObject, WKNavigationDelegate {
 
         // Download the file
         guard let (data, response) = try? await URLSession.shared.data(from: url),
-              let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+              let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200
+        else {
             logger.error("Failed to download extension")
             return
         }
@@ -470,7 +469,8 @@ class WebViewNavigationDelegate: NSObject, WKNavigationDelegate {
         }
 
         // Extract
-        let extensionsDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("extensions")
+        let extensionsDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("extensions")
         if !FileManager.default.fileExists(atPath: extensionsDir.path) {
             try? FileManager.default.createDirectory(at: extensionsDir, withIntermediateDirectories: true)
         }

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -57,7 +57,8 @@ struct ExtensionIconButton: NSViewRepresentable {
         @objc func clicked(_ sender: NSButton) {
             guard let context = extensionManager.controller.extensionContexts.first(where: { $0.webExtension == ext }),
                   let action = context.action(for: nil), action.presentsPopup,
-                  let popover = action.popupPopover else {
+                  let popover = action.popupPopover
+            else {
                 print("No popup for extension: \(ext.displayName ?? "Unknown")")
                 return
             }
@@ -81,7 +82,7 @@ struct URLBar: View {
     @State private var alertMessage: String?
 
     let onSidebarToggle: () -> Void
-    let size: CGSize = CGSize(width: 32, height: 32)
+    let size: CGSize = .init(width: 32, height: 32)
 
     private func getForegroundColor(_ tab: Tab) -> Color {
         // Convert backgroundColor to NSColor for luminance calculation
@@ -132,7 +133,7 @@ struct URLBar: View {
             picker.show(relativeTo: sourceRect, of: sourceView, preferredEdge: .minY)
         }
     }
-   
+
     private var extensionIconsView: some View {
         HStack(spacing: 4) {
             ForEach(extensionManager.installedExtensions, id: \.self) { ext in
@@ -142,14 +143,14 @@ struct URLBar: View {
         }
         .padding(.horizontal, 4)
         .alert("Notice", isPresented: .constant(alertMessage != nil), actions: {
-                   Button("OK", role: .cancel) {
-                       alertMessage = nil
-                   }
-               }, message: {
-                   if let message = alertMessage {
-                       Text(message)
-                   }
-               })
+            Button("OK", role: .cancel) {
+                alertMessage = nil
+            }
+        }, message: {
+            if let message = alertMessage {
+                Text(message)
+            }
+        })
     }
 
     var body: some View {
@@ -310,12 +311,12 @@ struct URLBar: View {
                         .allowsHitTesting(false)
                     )
 
-                     // Extension icons
-                     if !extensionManager.installedExtensions.isEmpty {
-                         extensionIconsView
-                     }
+                    // Extension icons
+                    if !extensionManager.installedExtensions.isEmpty {
+                        extensionIconsView
+                    }
 
-                     ShareLinkButton(
+                    ShareLinkButton(
                         isEnabled: true,
                         foregroundColor: buttonForegroundColor,
                         onShare: { sourceView, sourceRect in


### PR DESCRIPTION
# AI Assistance Notice:
I took help of ChatGPT-5 from chatgpt.com to generate code for NSOpenPanel and flattening the directory.
I did not know how this framework worked at all.. The logics for the changes were completely mine, I was shy of the implementational logic and syntax which was covered by AI.

# Changes:
- Fixes Problem with Importing Extensions (FileManager was not able to copy to Containers/com.orabrowser.app/... due to sandbox) -> Switched to using NSOpenPanel which copies the selected zip file to the desired directory and unzips the extension and then flattens it out to match the extension file structure.


- Minor UI + padding fixes in ExtensionSettingsView.