### PR TITLE
Fix: Cmd+W closes tab instead of window

### DIFF
--- a/ora/OraCommands.swift
+++ b/ora/OraCommands.swift
@@ -181,7 +181,7 @@ struct OraCommands: Commands {
                     keyWindow.performClose(nil)
                 }
             }
-            .keyboardShortcut("w", modifiers: .command)
+            .keyboardShortcut(KeyboardShortcuts.Window.close.keyboardShortcut)
             .disabled({
                 guard let keyWindow = NSApp.keyWindow else { return true }
                 return keyWindow.title != "Settings"


### PR DESCRIPTION
Fixes duplicate Cmd+W shortcut conflict. Close Window now uses Cmd+Shift+W.
Fixes #144 