### PR TITLE
fix: updated app data directory to Application Support/Ora/

### DIFF
--- a/ora/Common/Extensions/ModelConfiguration+Shared.swift
+++ b/ora/Common/Extensions/ModelConfiguration+Shared.swift
@@ -10,7 +10,7 @@ extension ModelConfiguration {
             return ModelConfiguration(
                 "OraData",
                 schema: Schema([TabContainer.self, History.self, Download.self]),
-                url: URL.applicationSupportDirectory.appending(path: "OraData.sqlite")
+                url: URL.applicationSupportDirectory.appending(path: "Ora/OraData.sqlite")
             )
         }
     }


### PR DESCRIPTION
Moved OraData.sqlite to a proper directory
Now brew can also properly delete app data during zap or uninstall