### PR TITLE
Set Favicons on MainThread

### DIFF
--- a/ora/Models/Tab.swift
+++ b/ora/Models/Tab.swift
@@ -157,9 +157,11 @@ class Tab: ObservableObject, Identifiable {
                 [weak self] sourceURL, success in
                 guard let self else { return }
                 if success {
-                    self.faviconLocalFile = saveURL
-                    if let sourceURL {
-                        self.favicon = sourceURL
+                    Task { @MainActor in
+                        self.faviconLocalFile = saveURL
+                        if let sourceURL {
+                            self.favicon = sourceURL
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Changed favicons to being set on the Main thread instead of a background thread calling NSURLSession which crashes my goated browser

### Changes:
Offloading the task to a main thread in the completion.
Hope fully matches what was required.