### PR TITLE
fix: use specific failing URL from error info for navigation failures

### DIFF
--- a/ora/Services/WebViewNavigationDelegate.swift
+++ b/ora/Services/WebViewNavigationDelegate.swift
@@ -386,7 +386,8 @@ class WebViewNavigationDelegate: NSObject, WKNavigationDelegate {
                 return
             }
 
-            tab?.setNavigationError(error, for: webView.url)
+            let failingURL = nsError.userInfo[NSURLErrorFailingURLErrorKey] as? URL ?? webView.url
+            tab?.setNavigationError(error, for: failingURL)
             onProgressChange?(100.0)
         }
         originalURL = nil // Clear stored URL on navigation failure


### PR DESCRIPTION
# Fix: use specific failing URL from error info for navigation failures

## Problem
In didFailProvisionalNavigation we used webView.url, which can be stale - or empty on the first navigation. As a result, Tab.swift constructed a URL from an empty value and the page didn't refresh. Closes #177.

## Solution
Read the failing URL from NSError.userInfo[NSURLErrorFailingURLErrorKey] and fall back to webView.url if missing. Pass this URL to tab?.setNavigationError(error, for:).

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Code follows formatting standards (automatic via git hooks)
- [x] **Descriptive title and description**: Clearly explain what changes were made and why
- [x] Include screenshots if UI changes made
- [x] References related issues if applicable
- [x] No duplicate functionality (checked existing codebase)
