### PR TITLE
Ability to rename tab titles (#201)

### DIFF
--- a/ora/Models/Tab.swift
+++ b/ora/Models/Tab.swift
@@ -26,6 +26,8 @@ class Tab: ObservableObject, Identifiable {
     var urlString: String
     var savedURL: URL?
     var title: String
+    var customTitle: String?
+
     var favicon: URL? // Add favicon property
     var createdAt: Date
     var lastAccessedAt: Date?
@@ -223,11 +225,12 @@ class Tab: ObservableObject, Identifiable {
                 if let title, !title.isEmpty {
                     self?.title = title
                     if let self {
-                        self.tabManager?.mediaController.syncTitleForTab(self.id, newTitle: title)
+                        self.tabManager?.mediaController.syncTitleForTab(self.id, newTitle: self.customTitle ?? title)
                     }
                 }
             }
         }
+
         delegate.onURLChange = { [weak self] url in
             DispatchQueue.main.async {
                 if let url {

--- a/ora/Modules/Launcher/Main/LauncherMain.swift
+++ b/ora/Modules/Launcher/Main/LauncherMain.swift
@@ -142,7 +142,8 @@ struct LauncherMain: View {
             suggestions.append(
                 LauncherSuggestion(
                     type: .openedTab,
-                    title: tab.title,
+                    title: tab.customTitle ?? tab.title,
+
                     url: tab.url,
                     faviconURL: tab.favicon,
                     faviconLocalFile: tab.faviconLocalFile,

--- a/ora/Modules/TabSwitch/FloatingTabSwitcher.swift
+++ b/ora/Modules/TabSwitch/FloatingTabSwitcher.swift
@@ -177,7 +177,7 @@ struct FloatingTabSwitcher: View {
             )
             .frame(width: 16, height: 16)
 
-            Text(tab.title)
+            Text(tab.customTitle ?? tab.title)
                 .font(.system(size: 12))
                 .foregroundColor(theme.foreground)
                 .lineLimit(1)

--- a/ora/Services/MediaController.swift
+++ b/ora/Services/MediaController.swift
@@ -53,9 +53,10 @@ final class MediaController: ObservableObject {
             if let idx = sessions.firstIndex(where: { $0.tabID == id }) { return idx }
             let session = Session(
                 tabID: id,
-                title: tab.title,
+                title: tab.customTitle ?? tab.title,
                 pageURL: tab.url,
                 favicon: tab.faviconLocalFile ?? tab.favicon,
+
                 isPlaying: false,
                 volume: 1.0,
                 canGoNext: false,
@@ -207,11 +208,12 @@ final class MediaController: ObservableObject {
         let playingSessions = sessions.filter(\.isPlaying)
         for session in playingSessions {
             if let tab = tabRefs[session.tabID]?.value,
-               let idx = sessions.firstIndex(where: { $0.tabID == session.tabID }),
-               !tab.title.isEmpty,
-               tab.title != sessions[idx].title
+               let idx = sessions.firstIndex(where: { $0.tabID == session.tabID })
             {
-                sessions[idx].title = tab.title
+                let displayTitle = tab.customTitle ?? tab.title
+                if !displayTitle.isEmpty, displayTitle != sessions[idx].title {
+                    sessions[idx].title = displayTitle
+                }
             }
         }
     }
@@ -229,13 +231,14 @@ final class MediaController: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self else { return }
             if let tab = self.tabRefs[tabID]?.value,
-               let idx = self.sessions.firstIndex(where: { $0.tabID == tabID }),
-               !tab.title.isEmpty,
-               tab.title != self.sessions[idx].title
+               let idx = self.sessions.firstIndex(where: { $0.tabID == tabID })
             {
-                self.sessions[idx].title = tab.title
-            } else if attempts > 1 {
-                self.scheduleTitleSync(for: tabID, attempts: attempts - 1, delay: delay)
+                let displayTitle = tab.customTitle ?? tab.title
+                if !displayTitle.isEmpty, displayTitle != self.sessions[idx].title {
+                    self.sessions[idx].title = displayTitle
+                } else if attempts > 1 {
+                    self.scheduleTitleSync(for: tabID, attempts: attempts - 1, delay: delay)
+                }
             }
         }
     }

--- a/ora/UI/TabItem.swift
+++ b/ora/UI/TabItem.swift
@@ -100,6 +100,9 @@ struct TabItem: View {
 
     @Environment(\.theme) private var theme
     @State private var isHovering = false
+    @State private var isRenaming = false
+    @State private var newTitle = ""
+    @FocusState private var isTextFieldFocused: Bool
 
     var body: some View {
         HStack {
@@ -124,6 +127,11 @@ struct TabItem: View {
                         isPrivate: privacyMode.isPrivate
                     )
             }
+        }
+        .onTapGesture(count: 2) {
+            newTitle = tab.customTitle ?? tab.title
+            isRenaming = true
+            isTextFieldFocused = true
         }
         .onTapGesture {
             onTap()
@@ -152,20 +160,6 @@ struct TabItem: View {
                 : nil
         )
         .contentShape(ConditionallyConcentricRectangle(cornerRadius: 10))
-        .onTapGesture {
-            onTap()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                if !tab.isWebViewReady {
-                    tab
-                        .restoreTransientState(
-                            historyManager: historyManager,
-                            downloadManager: downloadManager,
-                            tabManager: tabManager,
-                            isPrivate: privacyMode.isPrivate
-                        )
-                }
-            }
-        }
         .onHover { isHovering = $0 }
         .contextMenu { contextMenuItems }
         .animation(.spring(response: 0.2, dampingFraction: 0.8), value: isDragging)
@@ -173,10 +167,33 @@ struct TabItem: View {
     }
 
     private var tabTitle: some View {
-        Text(tab.title)
-            .font(.system(size: 13))
-            .foregroundColor(textColor)
-            .lineLimit(1)
+        Group {
+            if isRenaming {
+                TextField("Tab Title", text: $newTitle, onCommit: {
+                    tab.customTitle = newTitle.isEmpty ? nil : newTitle
+                    isRenaming = false
+                })
+                .font(.system(size: 13))
+                .textFieldStyle(.plain)
+                .foregroundColor(textColor)
+                .focused($isTextFieldFocused)
+                .onAppear {
+                    isTextFieldFocused = true
+                }
+                .onChange(of: isTextFieldFocused) { _, newValue in
+                    if !newValue, isRenaming {
+                        tab.customTitle = newTitle.isEmpty ? nil : newTitle
+                        isRenaming = false
+                    }
+                }
+
+            } else {
+                Text(tab.customTitle ?? tab.title)
+                    .font(.system(size: 13))
+                    .foregroundColor(textColor)
+                    .lineLimit(1)
+            }
+        }
     }
 
     private var backgroundColor: Color {
@@ -205,6 +222,16 @@ struct TabItem: View {
 
     @ViewBuilder
     private var contextMenuItems: some View {
+        Button(action: {
+            newTitle = tab.customTitle ?? tab.title
+            isRenaming = true
+            isTextFieldFocused = true
+        }) {
+            Label("Rename Tab", systemImage: "pencil")
+        }
+
+        Divider()
+
         Button(action: onPinToggle) {
             Label(
                 tab.type == .pinned ? "Unpin Tab" : "Pin Tab",


### PR DESCRIPTION
### What this PR does
This PR implements the feature to rename browser tabs via double-click or context menu, as requested in issue #201.

### Use Case
Web developers often manage multiple localhost or Swagger instances simultaneously. Allowing them to rename tabs improves readability and workflow.

### How to Test
1. Open the browser.
2. Open multiple tabs.
3. Double-click on a tab title or right-click and select "Rename".
4. Verify that the tab title updates correctly.

### Related Issue
Closes #201

<img width="476" height="618" alt="Screenshot 2026-01-24 at 15 10 54" src="https://github.com/user-attachments/assets/3d7bd77d-43fb-499c-bc2d-0a901f7a60b8" />

