### PR TITLE
feat(ui) : increase BrowserWebView, SidebarView and WindowsControl padding

### DIFF
--- a/ora/Modules/Browser/BrowserWebContentView.swift
+++ b/ora/Modules/Browser/BrowserWebContentView.swift
@@ -62,5 +62,8 @@ struct BrowserWebContentView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+        .background(theme.background)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .padding(5)
     }
 }

--- a/ora/Modules/Sidebar/SidebarView.swift
+++ b/ora/Modules/Sidebar/SidebarView.swift
@@ -59,7 +59,8 @@ struct SidebarView: View {
                     selectedContainer: container.name,
                     containers: containers
                 )
-                .padding(.horizontal, 10)
+                .padding(.leading, 14)
+                .padding(.trailing, 9)
                 .environmentObject(tabManager)
                 .environmentObject(historyManager)
                 .environmentObject(downloadManager)

--- a/ora/UI/WindowControls.swift
+++ b/ora/UI/WindowControls.swift
@@ -16,7 +16,8 @@ struct WindowControls: View {
                 WindowControlButton(type: .minimize, isHovered: $isHovered)
                 WindowControlButton(type: .zoom, isHovered: $isHovered)
             }
-            .padding(.horizontal, 8)
+            .padding(.leading, 16)
+            .padding(.top, 16)
             .onHover { hovering in
                 withAnimation(.easeInOut(duration: 0.1)) {
                     isHovered = hovering


### PR DESCRIPTION
**What this PR does**
This PR adds padding to the interface to improve the overall visual layout. By increasing the spacing around elements, the content becomes more readable and the UI feels less cluttered.

**Use Case**
Increased padding to enhance visual clarity and provide a cleaner, more spacious interface.

**How to Test**
Open the browser.
<img width="447" height="280" alt="Capture d’écran 2026-02-12 à 13 23 04" src="https://github.com/user-attachments/assets/973766f3-f00b-4d1f-a4cd-08742803d052" />
