### PR TITLE
fix: prevent draggedItem from resetting to nil on drag start

### DIFF
--- a/ora/Features/Sidebar/Views/ContainerView.swift
+++ b/ora/Features/Sidebar/Views/ContainerView.swift
@@ -91,6 +91,12 @@ struct ContainerView: View {
             }
         }
         .modifier(OraWindowDragGesture(isDragging: $isDragging))
+        .onChange(of: draggedItem) { _, new in
+            print("Dragging Item: \(new)")
+        }
+        .onChange(of: isDragging) { _, new in
+            print("isDragging: \(new)")
+        }
     }
 
     private var favoriteTabs: [Tab] {
@@ -147,7 +153,9 @@ struct ContainerView: View {
         draggedItem = tabId
         let provider = TabItemProvider(object: tabId.uuidString as NSString)
         provider.didEnd = {
-            draggedItem = nil
+            DispatchQueue.main.async {
+                draggedItem = nil
+            }
         }
         return provider
     }

--- a/ora/Features/Tabs/Views/TabItem.swift
+++ b/ora/Features/Tabs/Views/TabItem.swift
@@ -141,8 +141,9 @@ struct TabItem: View {
             }
         }
         .padding(8)
-        .opacity(isDragging ? 0.0 : 1.0)
-        .background(backgroundColor, in: .rect(cornerRadius: 10))
+//        .opacity(isDragging ? 0.0 : 1.0)
+//        .background(backgroundColor, in: .rect(cornerRadius: 10))
+        .background(isDragging ? .red : backgroundColor, in: .rect(cornerRadius: 10))
         .overlay(
             isDragging ?
                 ConditionallyConcentricRectangle(cornerRadius: 10)


### PR DESCRIPTION
Addresses #219
Still wip, this commit mainly helps surface the bug more clearly.