### PR TITLE
Update password window UI

### DIFF
--- a/ora/Features/Passwords/Views/PasswordsWindow.swift
+++ b/ora/Features/Passwords/Views/PasswordsWindow.swift
@@ -143,59 +143,79 @@ private struct PasswordsWindowView: View {
 
     private var lockedVaultState: some View {
         VStack(spacing: 18) {
-            Image(systemName: "lock.fill")
-                .font(.system(size: 56, weight: .regular))
-                .foregroundStyle(theme.mutedForeground.opacity(0.75))
+            ZStack(alignment: .bottomTrailing) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 60, weight: .regular))
+                    .foregroundStyle(Color.secondary.opacity(0.75))
+
+                if passwordManager.canUseBiometricAuthentication() {
+                    Button {
+                        unlockVault()
+                    } label: {
+                        Image(systemName: "touchid")
+                            .font(.system(size: 24, weight: .semibold))
+                            .foregroundStyle(Color.accentColor)
+                            .frame(width: 38, height: 38)
+                            .background(Color(.windowBackgroundColor).opacity(0.92))
+                            .clipShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Use Touch ID to unlock")
+                    .disabled(isAuthenticating)
+                }
+            }
 
             VStack(spacing: 8) {
                 Text("Passwords Are Locked")
                     .font(.title3.weight(.semibold))
 
-                Text("Use Touch ID or your Mac password to unlock your saved passwords.")
+                Text("Authenticate to view saved passwords.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 360)
             }
 
-            OraButton(
-                label: isAuthenticating ? "Unlocking..." : "Unlock Passwords",
-                variant: .outline,
-                isDisabled: isAuthenticating,
-                leadingIcon: passwordManager.canUseBiometricAuthentication() ? "touchid" : "lock.open"
-            ) {
+            Button {
                 unlockVault()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: passwordManager.canUseBiometricAuthentication() ? "touchid" : "lock.open")
+                    Text(isAuthenticating ? "Unlocking..." : "Unlock Passwords")
+                }
             }
+            .disabled(isAuthenticating)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .frame(maxWidth: .infinity, minHeight: 260, maxHeight: .infinity, alignment: .center)
     }
 
     private var passwordsTable: some View {
-        VStack(spacing: 0) {
-            passwordTableHeader
+        ScrollView(.horizontal, showsIndicators: true) {
+            VStack(spacing: 0) {
+                passwordTableHeader
 
-            Divider()
-                .overlay(theme.border.opacity(0.7))
+                Divider()
+                    .overlay(Color(.separatorColor).opacity(0.7))
 
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(filteredEntries, id: \.id) { entry in
-                        passwordTableRow(entry)
+                ScrollView(.vertical) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(filteredEntries, id: \.id) { entry in
+                            passwordTableRow(entry)
 
-                        if entry.id != filteredEntries.last?.id {
-                            Divider()
-                                .overlay(theme.border.opacity(0.45))
-                                .padding(.leading, 12)
+                            if entry.id != filteredEntries.last?.id {
+                                Divider()
+                                    .overlay(Color(.separatorColor).opacity(0.45))
+                                    .padding(.leading, 12)
+                            }
                         }
                     }
                 }
             }
+            .frame(minWidth: 800)
         }
-        .background(theme.solidWindowBackgroundColor)
+        .background(Color(.controlBackgroundColor).opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(theme.border.opacity(0.55), lineWidth: 1)
+                .stroke(Color(.separatorColor).opacity(0.55), lineWidth: 1)
         }
     }
 
@@ -208,7 +228,7 @@ private struct PasswordsWindowView: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
-        .background(theme.background.opacity(0.16))
+        .background(Color(.controlBackgroundColor).opacity(0.3))
     }
 
     private func passwordTableRow(_ entry: SavedPasswordSummary) -> some View {
@@ -313,7 +333,7 @@ private struct PasswordsWindowView: View {
                     .foregroundStyle(.red)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .frame(maxWidth: .infinity, minHeight: 200, maxHeight: .infinity, alignment: .center)
     }
 
     private func unlockVault() {


### PR DESCRIPTION
## Summary
Updated the password window UI to match the password list styling from settings view:
- Redesigned locked vault state with larger lock icon (60pt) and biometric authentication button overlay
- Added Touch ID button with circular background positioned at bottom-trailing of lock icon
- Simplified unlock messaging and button styling to use native SwiftUI components
- Replaced custom `OraButton` with standard `Button` for unlock action
- Updated color scheme to use system colors (`Color.secondary`, `Color.accentColor`, `Color(.separatorColor)`, `Color(.controlBackgroundColor)`) instead of theme colors
- Added horizontal scrolling support to password table with minimum width constraint (800pt)
- Set minimum height constraints for locked state (260pt) and empty state (200pt) views
- Updated divider and background opacities throughout for better visual consistency 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/e0773907-6b4d-4ae0-a311-b317714c5d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11" height="28"></picture></a> 